### PR TITLE
Import logging handlers

### DIFF
--- a/stoq/core.py
+++ b/stoq/core.py
@@ -62,6 +62,7 @@ import json
 import uuid
 import fcntl
 import logging
+import logging.handlers
 import requests
 import datetime
 import configparser

--- a/stoq/core.py
+++ b/stoq/core.py
@@ -62,7 +62,6 @@ import json
 import uuid
 import fcntl
 import logging
-import logging.handlers
 import requests
 import datetime
 import configparser
@@ -70,6 +69,7 @@ import configparser
 from bs4 import UnicodeDammit
 from pythonjsonlogger import jsonlogger
 from requests.exceptions import HTTPError
+from logging.handlers import RotatingFileHandler
 
 from stoq.plugins import StoqPluginManager
 from stoq.helpers import JsonComplexDecoder, JsonComplexEncoder
@@ -243,10 +243,9 @@ class Stoq(StoqPluginManager):
         self.log_path = os.path.abspath(os.path.join(self.log_dir, log_file))
 
         # Setup our logfile
-        file_handler = logging.handlers.RotatingFileHandler(filename=self.log_path,
-                                                            mode='a',
-                                                            maxBytes=int(self.log_maxbytes),
-                                                            backupCount=int(self.log_backup_count))
+        file_handler = RotatingFileHandler(
+            filename=self.log_path, mode='a', maxBytes=int(self.log_maxbytes),
+            backupCount=int(self.log_backup_count))
 
         # Setup our STDERR output
         stderr_handler = logging.StreamHandler()


### PR DESCRIPTION
Currently, running the `install.sh` script results in the following exception:
```
Traceback (most recent call last):
  File "./stoq-cli.py", line 32, in <module>
    stoq = Stoq(argv=sys.argv)
  File "/usr/local/stoq/.stoq-pyenv/lib/python3.5/site-packages/stoq-0.20.1-py3.5.egg/stoq/core.py", line 181, in __init__
    self.logger_init()
  File "/usr/local/stoq/.stoq-pyenv/lib/python3.5/site-packages/stoq-0.20.1-py3.5.egg/stoq/core.py", line 245, in logger_init
    file_handler = logging.handlers.RotatingFileHandler(filename=self.log_path,
AttributeError: module 'logging' has no attribute 'handlers'
```
Since `logger_init()` is called in `core.__init__()`, this exception might be more wide reaching, though I'm not sure why it hasn't been an issue before. Although stoq imports the `logging` module, it seems that RotatingFileHandler lives in the `logging.handlers` submodule: https://docs.python.org/3/library/logging.handlers.html