### PR TITLE
Shell out to pip instead of deprecated pip.main()

### DIFF
--- a/stoq/plugins.py
+++ b/stoq/plugins.py
@@ -1486,6 +1486,8 @@ class StoqDecoderPlugin(StoqPluginBase):
 
 class StoqPluginInstaller:
 
+    pip_exists_str = "already exists. Specify --upgrade to force replacement."
+    
     def __init__(self, stoq):
 
         self.stoq = stoq
@@ -1534,15 +1536,17 @@ class StoqPluginInstaller:
                     self.plugin,
                     '-t',
                     self.plugin_root,
-                    '--quiet',
                 ]
                 # Use pip to install/upgrade the plugin in the appropriate
                 # directory for this plugin category
                 if self.upgrade_plugin:
                     cmd.append('--upgrade')
 
-                subprocess.check_call(cmd)
-
+                output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+                if self.pip_exists_str.encode() in output:
+                    self.stoq.log.critical("Plugin {}".format(self.pip_exists_str))
+                    exit(-1)
+                                           
                 # Time to install the requirements, if they exist.
                 requirements = "{}/requirements.txt".format(self.plugin)
                 if os.path.isfile(requirements):


### PR DESCRIPTION
Using `pip.main()` throws an exception as of pip 10, and per the discussion [here](https://github.com/pypa/pip/issues/5240) it was never really supported. As noted there and in [this discussion](https://github.com/pypa/pip/issues/5240), a better alternative is to shell out to pip.

Rather than:
```
[2018-04-25 17:05:55,058 CRITICAL] stoq: Error installing requirements: module 'pip' has no attribute 'main'
```
It now outputs:
```
(.stoq-pyenv) stoq@ubuntu-xenial:~$ ./stoq-cli.py install /vagrant/stoq/stoq-plugins-public/extractor/gpg
[2018-04-25 15:47:47,933 INFO] stoq: Looking for plugin in /vagrant/stoq/stoq-plugins-public/extractor/gpg...
[2018-04-25 15:47:47,943 INFO] stoq: Installing gpg plugin into /usr/local/stoq/plugins/extractor...
Target directory /usr/local/stoq/plugins/extractor/gpg already exists. Specify --upgrade to force replacement.
[2018-04-25 15:48:54,782 INFO] stoq: Install complete.
```