### PR TITLE
Add support for plugin tests

### DIFF
--- a/stoq/cli.py
+++ b/stoq/cli.py
@@ -25,7 +25,7 @@ from stoq import __version__
 from stoq.core import Stoq
 from stoq.shell import StoqShell
 from stoq.logo import print_logo
-from stoq.helpers import runtests
+from stoq.helpers import run_stoq_tests, run_plugin_tests
 from stoq.plugins.installer import StoqPluginInstaller
 
 
@@ -105,11 +105,11 @@ def main():
         # of using argparse.
         try:
             if s.argv[2] == "stoq":
-                runtests(s)
+                run_stoq_tests(s)
             elif s.argv[2] == "all":
-                runtests(s, everything=True)
+                run_plugin_tests(s)
             else:
-                runtests(s, plugin=s.argv[2:])
+                run_plugin_tests(s, plugin=s.argv[2:])
         except IndexError:
             parser.print_usage()
             print("No test type provided. Valid options are: {stoq|all|plugin name ...}")

--- a/stoq/cli.py
+++ b/stoq/cli.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import unittest
 
 from time import sleep
 from pathlib import Path
@@ -26,6 +25,7 @@ from stoq import __version__
 from stoq.core import Stoq
 from stoq.shell import StoqShell
 from stoq.logo import print_logo
+from stoq.helpers import runtests
 from stoq.plugins.installer import StoqPluginInstaller
 
 
@@ -39,20 +39,23 @@ def main():
 
     logo = print_logo()
 
-    parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter,
-                            usage='''
-    {}
-    %(prog)s [command] [<args>]
+    parser = ArgumentParser(
+        formatter_class=RawDescriptionHelpFormatter,
+        description='''
+    stoQ - an automated analysis framework
 
+            {}
     Available Commands:
         help     Display help message
         shell    Launch an interactive shell
         list     List available plugins
         worker   Load specified worker plugin
         install  Install a stoQ plugin
-        runtests Run stoQ tests
-    '''.format(logo),
-                            epilog='''
+        test     Run stoQ tests
+
+            '''.format(logo),
+        usage='%(prog)s [command] [<args>]',
+        epilog='''
     Examples:
 
         - Scan a file with yara:
@@ -80,7 +83,7 @@ def main():
 
     ''')
 
-    parser.add_argument("command", help="Subcommand to be run")
+    parser.add_argument(dest="command", help="Commands")
     options = parser.parse_args(s.argv[1:2])
 
     if not options.command or options.command == 'help':
@@ -97,21 +100,19 @@ def main():
     elif options.command == "shell":
         StoqShell(s).cmdloop()
 
-    elif options.command == "runtests":
-        # Use tests from installed $CWD/tests, otherwise, try to use the install stoQ tests
-        test_path = os.path.join(os.getcwd(), "tests")
-        if not os.path.isdir(test_path):
-            try:
-                test_path = os.path.join(os.path.dirname(stoq.__file__), "tests")
-            except ImportError:
-                print("Test suite not found. Is stoQ installed or are tests in {}?".format(test_path))
-                exit(1)
-
-        test_suite = unittest.TestLoader().discover(test_path, pattern='*_tests.py')
-        test_result = unittest.TextTestRunner(verbosity=1).run(test_suite)
-        if not test_result.wasSuccessful():
-            exit("Unit tests failed")
-
+    elif options.command == "test":
+        # We are going to manually parse the command line options here instead
+        # of using argparse.
+        try:
+            if s.argv[2] == "stoq":
+                runtests(s)
+            elif s.argv[2] == "all":
+                runtests(s, everything=True)
+            else:
+                runtests(s, plugin=s.argv[2:])
+        except IndexError:
+            parser.print_usage()
+            print("No test type provided. Valid options are: {stoq|all|plugin name ...}")
     else:
         # Initialize and load the worker plugin and make it an object of our
         # stoq class

--- a/stoq/helpers.py
+++ b/stoq/helpers.py
@@ -114,14 +114,29 @@ def flatten(data, delim='_'):
     flatten_dict(data)
     return result
 
-
-def runtests(s, plugin=None, everything=False):
+def run_stoq_tests(s):
     """
-    Run stoQ tests
+    Run stoQ framework tests
 
-    :param object s: Stoq() object
-    :param str plugin: stoQ plugin name
-    :param bool everything: Test all plugin
+    :param Stoq s: Stoq() object
+
+    """
+    try:
+        test_path = os.path.join(
+            os.path.dirname(stoq.__file__), "tests")
+    except ImportError:
+        s.log.error(
+            "Test suite not found. Is stoQ installed or are tests in {}?".format(
+                test_path))
+    else:
+        run_test(test_path)
+
+def run_plugin_tests(s, plugin=None):
+    """
+    Run stoQ plugin tests
+
+    :param Stoq s: Stoq() object
+    :param list plugin: stoQ plugin names
 
     """
 
@@ -138,7 +153,7 @@ def runtests(s, plugin=None, everything=False):
                 s.log.error("Plugin does not exist: {}".format(plg))
             else:
                 tests.append(test_path)
-    elif everything:
+    else:
         for _, config in s.__collected_plugins__.items():
             test_path = os.path.join(
                 os.path.abspath(
@@ -146,21 +161,14 @@ def runtests(s, plugin=None, everything=False):
                         os.path.dirname(
                             config.get("Core", "Config")), "tests")))
             tests.append(test_path)
-    else:
-        try:
-            test_path = os.path.join(
-                os.path.dirname(stoq.__file__), "tests")
-        except ImportError:
-            s.log.error(
-                "Test suite not found. Is stoQ installed or are tests in {}?".format(
-                    test_path))
-        else:
-            tests.append(test_path)
 
     for test_path in tests:
         if not os.path.isdir(test_path):
             s.log.error("Invalid test suite {} ..skipping".format(test_path))
             continue
 
-        test_suite = unittest.TestLoader().discover(test_path, pattern='*_tests.py')
-        unittest.TextTestRunner(verbosity=1).run(test_suite)
+        run_test(test_path)
+
+def run_test(test_path):
+    test_suite = unittest.TestLoader().discover(test_path, pattern='*_tests.py')
+    unittest.TextTestRunner(verbosity=1).run(test_suite)

--- a/stoq/plugins/__init__.py
+++ b/stoq/plugins/__init__.py
@@ -172,6 +172,7 @@ class StoqPluginManager:
                                 config["Core"]["Category"] = category
                                 config["Core"]["Module"] = module_path
                                 config["Core"]["Root"] = plugin_dir_candidate
+                                config["Core"]["Config"] = plugin_path
                                 self.__collected_plugins__[name] = config
                             else:
                                 self.log.warning("Found {} but no module {}, skipping".format(plugin_path, module_path))


### PR DESCRIPTION
- `runtests` command renamed to `test`
- `test` command now supports arguments `stoq`, `all`, or list of plugin names