### PR TITLE
Move dispatched_to from a list to a dict.

### DIFF
--- a/stoq/core.py
+++ b/stoq/core.py
@@ -217,6 +217,7 @@ class Stoq(StoqPluginManager):
         extracted = []
         errors = []
         for dispatch in self._get_dispatches(payload, add_dispatch, request_meta):
+            payload_results.plugins['workers'].append(dispatch.plugin_name)
             try:
                 if dispatch.plugin_name:
                     plugin = self.load_plugin(dispatch.plugin_name)
@@ -229,7 +230,6 @@ class Stoq(StoqPluginManager):
                 self.log.exception(msg)
                 errors.append(msg)
                 continue
-            payload_results.dispatched_to.append(dispatch.plugin_name)
             try:
                 worker_response = plugin.scan(payload, dispatch.meta,
                                               request_meta)
@@ -250,7 +250,7 @@ class Stoq(StoqPluginManager):
                 errors.extend(worker_response.errors)
         if request_meta.archive_payloads and payload.payload_meta.should_archive:
             for plugin_name, archiver in self._loaded_archiver_plugins.items():
-                payload_results.dispatched_to.append(plugin_name)
+                payload_results.plugins['archivers'].append(plugin_name)
                 try:
                     archiver_response = archiver.archive(payload, request_meta)
                 except Exception as e:

--- a/stoq/data_classes.py
+++ b/stoq/data_classes.py
@@ -39,31 +39,31 @@ class RequestMeta():
 
 class PayloadResults():
     def __init__(self,
-                 payload_id: str,
+                 payload_id: int,
                  md5: str,
                  sha1: str,
                  sha256: str,
                  sha512: str,
                  size: int,
+                 plugins: Dict[str, List],
                  payload_meta: Optional[PayloadMeta] = None,
                  extracted_from: Optional[int] = None,
                  extracted_by: Optional[str] = None,
                  workers: Optional[Dict[str, Dict]] = None,
                  archivers: Optional[Dict[str, Dict]] = None,
-                 decorators: Optional[Dict[str, Dict]] = None,
-                 dispatched_to: List[str] = None) -> None:
+                 decorators: Optional[Dict[str, Dict]] = None) -> None:
         self.payload_id = payload_id
         self.md5 = md5
         self.sha1 = sha1
         self.sha256 = sha256
         self.sha512 = sha512
         self.size = size
+        self.plugins = plugins
         self.payload_meta = payload_meta
         self.extracted_from = extracted_from  # payload_id of parent payload
         self.extracted_by = extracted_by
         self.workers = {} if workers is None else workers
         self.archivers = {} if archivers is None else archivers
-        self.dispatched_to = [] if dispatched_to is None else dispatched_to
 
     @classmethod
     def from_payload(cls, payload: Payload,
@@ -73,7 +73,8 @@ class PayloadResults():
         sha256 = helpers.get_sha256(payload.content)
         sha512 = helpers.get_sha512(payload.content)
         size = len(payload.content)
-        return cls(payload_id, md5, sha1, sha256, sha512, size,
+        plugins = {'workers': [], 'archivers': []}
+        return cls(payload_id, md5, sha1, sha256, sha512, size, plugins,
                    payload.payload_meta, payload.extracted_from,
                    payload.extracted_by)
 


### PR DESCRIPTION
Move dispatched_to from a list to a dict. The keys in the dict are the workers and archivers that we attempt to dispatch to, even if the dispatch is not successful.