### PR TITLE
Add functionality for a provider to return a task as well as payload.

### DIFF
--- a/stoq/core.py
+++ b/stoq/core.py
@@ -52,7 +52,8 @@ class Stoq(StoqPluginManager):
         plugin_dir_list: List[str] = None,
         plugin_opts: Dict[str, Dict] = None,
         providers: List[str] = None,
-        archivers: List[str] = None,
+        source_archivers: List[str] = None,
+        dest_archivers: List[str] = None,
         connectors: List[str] = None,
         dispatchers: List[str] = None,
         deep_dispatchers: List[str] = None,
@@ -96,10 +97,20 @@ class Stoq(StoqPluginManager):
             providers_str = config.get('core', 'providers', fallback='')
             providers = [d.strip() for d in providers_str.split(',') if d.strip()]
         self._loaded_provider_plugins = {d: self.load_plugin(d) for d in providers if d}
-        if not archivers:
-            arch_str = config.get('core', 'archivers', fallback='')
-            archivers = [d.strip() for d in arch_str.split(',') if d.strip()]
-        self._loaded_archiver_plugins = {d: self.load_plugin(d) for d in archivers if d}
+        if not source_archivers:
+            source_arch_str = config.get('core', 'source_archivers', fallback='')
+            source_archivers = [
+                d.strip() for d in source_arch_str.split(',') if d.strip()
+            ]
+        self._loaded_source_archiver_plugins = {
+            d: self.load_plugin(d) for d in source_archivers if d
+        }
+        if not dest_archivers:
+            dest_arch_str = config.get('core', 'dest_archivers', fallback='')
+            dest_archivers = [d.strip() for d in dest_arch_str.split(',') if d.strip()]
+        self._loaded_dest_archiver_plugins = {
+            d: self.load_plugin(d) for d in dest_archivers if d
+        }
         if not connectors:
             conn_str = config.get('core', 'connectors', fallback='')
             connectors = [d.strip() for d in conn_str.split(',') if d.strip()]
@@ -219,7 +230,29 @@ class Stoq(StoqPluginManager):
             while len(future_to_name) > 0 or payload_queue.qsize() > 0:
                 try:
                     # Using get_nowait results in high CPU churn
-                    self.scan_payload(payload_queue.get(timeout=0.1))
+                    task = payload_queue.get(timeout=0.1)
+                    payload = None
+                    # Determine whether the provider has returned a `Payload`, or a task.
+                    # If it is a task, load the defined archiver plugin to load the
+                    # `Payload`, otherwise, simply continue on with the scanning.
+                    if isinstance(task, Payload):
+                        payload = task
+                    else:
+                        for (
+                            source_name,
+                            source_archiver,
+                        ) in self._loaded_source_archiver_plugins.items():
+                            try:
+                                payload = source_archiver.get(task)
+                                if isinstance(payload, Payload):
+                                    break
+                            except Exception as e:
+                                self.log.warn(
+                                    f'{task} not found in archive {source_name}'
+                                )
+                    if not payload:
+                        raise StoqException('Unable to determine Payload from {task}')
+                    self.scan_payload(payload)
                 except queue.Empty:
                     pass
                 for future in [fut for fut in future_to_name if fut.done()]:
@@ -326,7 +359,7 @@ class Stoq(StoqPluginManager):
 
         payload_results = PayloadResults.from_payload(payload)
         if request_meta.archive_payloads and payload.payload_meta.should_archive:
-            for plugin_name, archiver in self._loaded_archiver_plugins.items():
+            for plugin_name, archiver in self._loaded_dest_archiver_plugins.items():
                 payload.plugins_run['archivers'].append(plugin_name)
                 try:
                     archiver_response = archiver.archive(payload, request_meta)

--- a/stoq/plugin_manager.py
+++ b/stoq/plugin_manager.py
@@ -44,7 +44,8 @@ class StoqPluginManager:
         self._loaded_plugins: Dict[str, BasePlugin] = {}
         self._loaded_provider_plugins: Dict[str, ProviderPlugin] = {}
         self._loaded_worker_plugins: Dict[str, WorkerPlugin] = {}
-        self._loaded_archiver_plugins: Dict[str, ArchiverPlugin] = {}
+        self._loaded_source_archiver_plugins: Dict[str, ArchiverPlugin] = {}
+        self._loaded_dest_archiver_plugins: Dict[str, ArchiverPlugin] = {}
         self._loaded_dispatcher_plugins: Dict[str, DispatcherPlugin] = {}
         self._loaded_deep_dispatcher_plugins: Dict[str, DeepDispatcherPlugin] = {}
         self._loaded_connector_plugins: List[ConnectorPlugin] = []

--- a/stoq/plugins/archiver.py
+++ b/stoq/plugins/archiver.py
@@ -27,3 +27,7 @@ class ArchiverPlugin(BasePlugin):
         self, payload: Payload, request_meta: RequestMeta
     ) -> Optional[ArchiverResponse]:
         pass
+
+    @abstractmethod
+    def get(self, task: str) -> Optional[Payload]:
+        pass

--- a/stoq/tests/data/plugins/archiver/dummy_archiver/dummy_archiver.py
+++ b/stoq/tests/data/plugins/archiver/dummy_archiver/dummy_archiver.py
@@ -25,3 +25,6 @@ class DummyArchiver(ArchiverPlugin):
         self, payload: Payload, request_meta: RequestMeta
     ) -> Optional[ArchiverResponse]:
         return None
+
+    def get(self, task: str) -> Optional[Payload]:
+        return None

--- a/stoq/tests/data/plugins/archiver/simple_archiver/simple_archiver.py
+++ b/stoq/tests/data/plugins/archiver/simple_archiver/simple_archiver.py
@@ -16,13 +16,14 @@
 
 from typing import Optional
 
-from stoq.data_classes import ArchiverResponse, Payload, RequestMeta
+from stoq.data_classes import ArchiverResponse, Payload, RequestMeta, PayloadMeta
 from stoq.plugins import ArchiverPlugin
 
 
 class SimpleArchiver(ArchiverPlugin):
     RAISE_EXCEPTION = False
     RETURN_ERRORS = False
+    PAYLOAD = None
 
     def archive(
         self, payload: Payload, request_meta: RequestMeta
@@ -33,3 +34,8 @@ class SimpleArchiver(ArchiverPlugin):
         if self.RETURN_ERRORS:
             ar.errors += ['Test error please ignore']
         return ar
+
+    def get(self, task: str) -> Optional[Payload]:
+        if self.RAISE_EXCEPTION:
+            raise Exception('Test exception please ignore')
+        return Payload(self.PAYLOAD, PayloadMeta(extra_data={'task': task}))

--- a/stoq/tests/data/plugins/provider/simple_provider/simple_provider.py
+++ b/stoq/tests/data/plugins/provider/simple_provider/simple_provider.py
@@ -22,8 +22,12 @@ from stoq.plugins import ProviderPlugin
 
 class SimpleProvider(ProviderPlugin):
     RAISE_EXCEPTION = False
+    RETURN_PAYLOAD = True
 
     def ingest(self, queue: Queue) -> None:
         if self.RAISE_EXCEPTION:
             raise RuntimeError('Test exception, please ignore')
-        queue.put(Payload(b'Important stuff'))
+        if self.RETURN_PAYLOAD:
+            queue.put(Payload(b'Important stuff'))
+        else:
+            queue.put('This is a task from provider')


### PR DESCRIPTION
Allow providers to return a task, which is then used to retrieve a payload for scanning from an `ArchiverPlugin` defined by `source_archivers` upon instantiation of `Stoq`