### PR TITLE
Add default for PayloadMeta extra_data

### DIFF
--- a/stoq/data_classes.py
+++ b/stoq/data_classes.py
@@ -24,11 +24,11 @@ class PayloadMeta:
     def __init__(
         self,
         should_archive: bool = True,
-        extra_data: Optional[Dict] = None,
+        extra_data: Dict = None,
         dispatch_to: List[str] = None,
     ) -> None:
         self.should_archive = should_archive
-        self.extra_data = extra_data
+        self.extra_data = {} if extra_data is None else extra_data
         self.dispatch_to = [] if dispatch_to is None else dispatch_to
 
     def __str__(self) -> str:
@@ -64,7 +64,7 @@ class RequestMeta:
         self,
         archive_payloads: bool = True,
         source: Optional[str] = None,
-        extra_data: Optional[Dict] = None,
+        extra_data: Dict = None,
     ) -> None:
         self.archive_payloads = archive_payloads
         self.source = source


### PR DESCRIPTION
We should default PayloadMeta.extra_data to an empty dictionary so that the user doesn't have to do verbose `if payload.payload_meta.extra_data is not None and ...` checks when they want to access it. This matches the behavior of RequestMeta. Also updating type signatures to reflect the actual underlying types (which is how these would look if they were real python 3.7 data classes).