### PR TITLE
Don't make Archiver.get() a required abstract method

### DIFF
--- a/stoq/plugins/archiver.py
+++ b/stoq/plugins/archiver.py
@@ -22,7 +22,6 @@ from stoq.plugins import BasePlugin
 
 
 class ArchiverPlugin(BasePlugin):
-    @abstractmethod
     def archive(
         self, payload: Payload, request_meta: RequestMeta
     ) -> Optional[ArchiverResponse]:

--- a/stoq/plugins/archiver.py
+++ b/stoq/plugins/archiver.py
@@ -28,6 +28,5 @@ class ArchiverPlugin(BasePlugin):
     ) -> Optional[ArchiverResponse]:
         pass
 
-    @abstractmethod
     def get(self, task: str) -> Optional[Payload]:
         pass


### PR DESCRIPTION
The `@abstractmethod` decorator enforces that subclasses are required to override a given method. Since not all uses of `ArchiverPlugin` need the `get()` method, it shouldn't be marked as an abstract method (the same could now be said about the `archive` method, feel free to add that change). Note that the default `pass` behavior should work fine with the existing `get()` calls: https://github.com/PUNCH-Cyber/stoq/blob/v2/stoq/core.py#L249