### PR TITLE
Change sending str to ArchiverResponse to ProviderPlugin.get()

### DIFF
--- a/stoq/core.py
+++ b/stoq/core.py
@@ -291,6 +291,7 @@
 """
 
 import os
+import json
 import queue
 import logging
 import configparser
@@ -308,6 +309,7 @@ from stoq.data_classes import (
     PayloadResults,
     RequestMeta,
     StoqResponse,
+    ArchiverResponse,
 )
 
 import stoq.helpers as helpers
@@ -576,7 +578,8 @@ class Stoq(StoqPluginManager):
                             source_archiver,
                         ) in self._loaded_source_archiver_plugins.items():
                             try:
-                                payload = source_archiver.get(task)
+                                ar = ArchiverResponse(task)
+                                payload = source_archiver.get(ar)
                                 if isinstance(payload, Payload):
                                     break
                             except Exception as e:
@@ -717,6 +720,7 @@ class Stoq(StoqPluginManager):
                     payload_results.archivers[plugin_name] = archiver_response.results
                 if archiver_response.errors is not None:
                     errors[plugin_name].extend(archiver_response.errors)
+
         return (payload_results, extracted, errors)
 
     def _init_logger(

--- a/stoq/tests/data/plugins/archiver/simple_archiver/simple_archiver.py
+++ b/stoq/tests/data/plugins/archiver/simple_archiver/simple_archiver.py
@@ -35,7 +35,7 @@ class SimpleArchiver(ArchiverPlugin):
             ar.errors += ['Test error please ignore']
         return ar
 
-    def get(self, task: str) -> Optional[Payload]:
+    def get(self, task: ArchiverResponse) -> Optional[Payload]:
         if self.RAISE_EXCEPTION:
             raise Exception('Test exception please ignore')
-        return Payload(self.PAYLOAD, PayloadMeta(extra_data={'task': task}))
+        return Payload(self.PAYLOAD, PayloadMeta(extra_data=task.results))

--- a/stoq/tests/data/plugins/provider/simple_provider/simple_provider.py
+++ b/stoq/tests/data/plugins/provider/simple_provider/simple_provider.py
@@ -30,4 +30,4 @@ class SimpleProvider(ProviderPlugin):
         if self.RETURN_PAYLOAD:
             queue.put(Payload(b'Important stuff'))
         else:
-            queue.put('This is a task from provider')
+            queue.put({"task": "This is a task from provider"})

--- a/stoq/tests/test_core.py
+++ b/stoq/tests/test_core.py
@@ -19,7 +19,7 @@ import tempfile
 import unittest
 from unittest.mock import create_autospec, Mock
 
-from stoq import PayloadMeta, RequestMeta, Stoq, StoqException
+from stoq import PayloadMeta, RequestMeta, Stoq, StoqException, ArchiverResponse, Payload
 import stoq.tests.utils as utils
 
 
@@ -273,10 +273,9 @@ class TestCore(unittest.TestCase):
         s = Stoq(base_dir=utils.get_data_dir(), source_archivers=['simple_archiver'])
         simple_archiver = s.load_plugin('simple_archiver')
         simple_archiver.PAYLOAD = b'This is a payload'
-        task = 'this is a task message'
+        task = ArchiverResponse(results={'path': '/tmp/123'})
         payload = simple_archiver.get(task)
-        self.assertIn('task', payload.payload_meta.extra_data)
-        self.assertEqual(payload.payload_meta.extra_data['task'], task)
+        self.assertEqual('/tmp/123', payload.payload_meta.extra_data['path'])
         self.assertEqual(payload.content, simple_archiver.PAYLOAD)
 
     def test_dest_archive(self):


### PR DESCRIPTION
Ensure that when archive() and get() are called, the metadata is in sync