### PR TITLE
Clarified $STOQ_HOME in the initial setup documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,7 @@ stoQ requires a minimum of python 3.6 and is recommended to be run in a `python 
 
 Initial Setup
 -------------
-Setup a \$STOQ_HOME (defaults to ~/.stoq/plugins) folder and virtual environment::
+Setup a \$STOQ_HOME (defaults to ~/.stoq) folder, the necessary plugin folder and a virtual environment::
 
     $ mkdir -p ~/.stoq/plugins
     $ python3 -m venv ~/.stoq/.venv


### PR DESCRIPTION
$STOQ_HOME points to the stoq base directory and not the plugin directory.

Added an extra comment about the plugin folder to make the mkdir command clearer