### PR TITLE
Cleanup defining plugin configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Provide better logging when a plugin is installed from github as a non-root user outside of a venv
 - Gracefully handle exceptions in `ConnectorPlugins`
 
+### Changed
+
+- Improve handling of plugin configuration options. Plugin options can now also be in stoq.cfg. (Thanks for feedback @chemberger!)
+- Set default precendence for plugin configuration options to be 1) `plugin_opts` when instantiating `Stoq`, 2) Plugin config file, 3) `stoq.cfg` (Thanks for feedback @chemberger!)
+
 ## [2.0.2] - 2019-01-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve handling of plugin configuration options. Plugin options can now also be in stoq.cfg. (Thanks for feedback @chemberger!)
-- Set default precendence for plugin configuration options to be 1) `plugin_opts` when instantiating `Stoq`, 2) Plugin config file, 3) `stoq.cfg` (Thanks for feedback @chemberger!)
+- Set default precendence for plugin configuration options to be 1) `plugin_opts` when instantiating `Stoq`, 2) `stoq.cfg`, 3) Plugin config file (Thanks for feedback @chemberger!)
 
 ## [2.0.2] - 2019-01-14
 

--- a/docs/dev/plugin_overview.rst
+++ b/docs/dev/plugin_overview.rst
@@ -19,7 +19,62 @@ For a full listing of all publicly available plugins, check out the `stoQ public
 Configuration
 *************
 
-Each plugin must have an ``.stoq`` configuration file. The configuration file resides in
+Plugins may be provided configuration options in one of four ways. In order of precendece:
+
+    - From the command line
+    - Upon instantiation of `Stoq()`
+    - Defined in `stoq.cfg`
+    - Defined in the plugin's `.stoq` configuration file
+
+.. _pluginconfigcmdline:
+
+Command Line
+------------
+
+When running ``stoq`` from the command line, simply add ``--plugin-opts`` to your arguments
+followed by the desired plugin options. The syntax for plugin options is::
+
+    plugin_name:option=value
+
+For example, if we want to tell the plugin ``dirmon`` to monitor the directory ``/tmp/monitor``
+for new files by setting the option ``source_dir``, the syntax would be::
+
+    dirmon:source_dir=/tmp/monitor
+
+
+.. _pluginconfiginstantiation:
+
+Instantiation
+-------------
+
+When using stoQ as a framework, plugin options may be defined when instantiating ``Stoq`` using the ``plugin_opts``
+argument::
+
+    >>> from stoq import Stoq
+    >>> plugin_options = {'dirmon': {'source_dir': '/tmp/monitor'}}
+    >>> s = Stoq(plugin_opts=plugin_options)
+
+
+.. _pluginconfigstoqcfg:
+
+stoq.cfg
+--------
+
+The recommended location for storing static plugin configuration options is in `stoq.cfg`.  The reason for this
+if all plugin options defined in the plugin's `.stoq` file will be overwritten when the plugin is upgraded.
+
+To define plugin options in `stoq.cfg` simply add a section header of the plugin name, then define the plugin options::
+
+    [dirmon]
+    source_dir = /tmp/monitor
+
+
+.. _pluginconfigpluginstoq:
+
+Plugin .stoq configuration file
+--------------------------------
+
+Each plugin must have a ``.stoq`` configuration file. The configuration file resides in
 the same directory as the plugin module. The plugin's configuration file allows for
 configuring a plugin with default or static settings. The configuration file is a standard
 YAML file and is parsed using the ``configparser`` module. The following is an example
@@ -55,37 +110,14 @@ Additionally, some optional settings may be defined::
 * **options**
     - **min_stoq_version**: Minimum version of stoQ required to work properly. If the version of `stoQ` is less than the version defined, a warning will be raised.
 
-Custom settings may be added as required for plugins, but the plugins must be configured to
-load and set them. For example, our configuration file may be::
+.. note::
+    Plugin options *must* be under the `[options]` section header to be accessible via the other plugin configuration options.J
 
-    [Core]
-    Name = example_plugin
-    Module = example_plugin
-
-    [Documentation]
-    Author = PUNCH Cyber
-    Version = 0.1
-    Website = https://github.com/PUNCH-Cyber/stoq-plugins-public
-    Description = Example stoQ Plugin
-
-    [worker]
-    source = /tmp
-
-
-Now, in the ``__init__`` method of our plugin class, we can ensure we define the ``source``
-setting under the ``worker`` section of the configuration file::
-
-
-        if plugin_opts and 'source' in plugin_opts:
-            self.source = plugin_opts['source']
-        elif config.has_option('worker', 'source'):
-            self.source = config.get('worker', 'source')
-
-
-First, we are checking for any plugin options were provided to ``Stoq`` at instantiation or at the
-:ref:`command line <pluginoptions>`. If not, it will check the plugin's configuration file for
-the ``source`` setting under the ``worker`` section. If ``source`` is defined in either, the
-setting will be made available to the plugin by defining ``self.source``.
+.. warning::
+    Plugin configuration options may be overwritten when a plugin is upgraded. Upgrading plugins is a destructive
+    operation. This will overwrite/remove all data within the plugins directory, to include the plugin configuration
+    file. It is highly recommended that the plugin directory be backed up regularly to ensure important information
+    is not lost, or plugin configuration options be defined in `stoq.cfg`.
 
 
 .. _multiclass:

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -34,6 +34,8 @@ look for ``stoq.cfg`` in ``$STOQ_HOME`` if running from the command line, or ``$
 used as a library.
 
 
+Plugin options may also be defined in `stoq.cfg`. For more information on how
+
 .. _stoqhome:
 
 $STOQ_HOME
@@ -281,32 +283,10 @@ to what stoQ can do. For more command line options in `run` mode, simply run::
 
     $ stoq run -h
 
-.. _pluginoptions:
+Plugin configuration
+--------------------
 
-Plugin Options
---------------
-
-Plugin options allows for configuration settings of plugins to be modified upon instantiation.
-This is extremely useful when you need to change a configuration options on the fly, such as
-our `run` mode example above.
-
-When running ``stoq`` from the command line, simply add ``--plugin-opts`` to your arguments
-followed by the desired plugin options. The syntax for plugin options is::
-
-    plugin_name:option=value
-
-For example, if we want to tell the plugin ``dirmon`` to monitor the directory ``/tmp/monitor``
-for new files by setting the option ``source_dir``, the syntax would be::
-
-    dirmon:source_dir=/tmp/monitor
-
-Additionally, plugin options may be defined when instantiating ``Stoq`` using the ``plugin_opts``
-argument::
-
-    >>> from stoq import Stoq
-    >>> plugin_options = {'dirmon': {'source_dir': '/tmp/monitor'}}
-    >>> s = Stoq(plugin_opts=plugin_options)
-
+Plugin configurations may be defined in several ways, see :ref:`plugin configuration <pluginconfig>`.
 
 RequestMeta Options
 -------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -115,7 +115,7 @@ Plugins may be upgraded (or downgraded) by adding the `--upgrade` command line o
 .. warning::
     Upgrading plugins is a destructive operation. This will overwrite/remove all data within the plugins directory,
     to include the plugin configuration file. It is highly recommended that the plugin directory be backed up
-    regularly to ensure important information is not lost.
+    regularly to ensure important information is not lost, or plugin configuration options be defined in `stoq.cfg`.
 
 .. _devenv:
 

--- a/stoq/core.py
+++ b/stoq/core.py
@@ -392,7 +392,7 @@ class Stoq(StoqPluginManager):
             )
             plugin_dir_list = [d.strip() for d in plugin_dir_str.split(',')]
 
-        super().__init__(plugin_dir_list, plugin_opts)
+        super().__init__(plugin_dir_list, plugin_opts, config)
 
         if not providers:
             providers_str = config.get('core', 'providers', fallback='')
@@ -650,7 +650,7 @@ class Stoq(StoqPluginManager):
             # Normal dispatches are the "1st round" of scanning
             payload.plugins_run['workers'][0].append(plugin_name)
             try:
-                worker_response = plugin.scan(payload, request_meta) # pyre-ignore[16]
+                worker_response = plugin.scan(payload, request_meta)  # pyre-ignore[16]
             except Exception as e:
                 msg = 'worker:failed to scan'
                 self.log.exception(msg)

--- a/stoq/plugin_manager.py
+++ b/stoq/plugin_manager.py
@@ -20,7 +20,7 @@ import logging
 import configparser
 import importlib.util
 from pkg_resources import parse_version
-from typing import Dict, List, Optional, Set, Tuple, Any
+from typing import Dict, List, Optional, Tuple, Any
 
 from .exceptions import StoqException
 from stoq.plugins import (
@@ -40,7 +40,7 @@ class StoqPluginManager:
         self,
         plugin_dir_list: List[str],
         plugin_opts: Optional[Dict[str, Dict]] = None,
-        stoq_config: configparser.ConfigParser = None,
+        stoq_config: Optional[configparser.ConfigParser] = None,
     ) -> None:
         self._stoq_config = stoq_config
         self._plugin_opts = {} if plugin_opts is None else plugin_opts
@@ -154,7 +154,9 @@ class StoqPluginManager:
         # 1) plugin options provided at instatiation of `Stoq()`
         # 2) `plugin_name.stoq`
         # 3) plugin configuration in `stoq.cfg`
-        if self._stoq_config and self._stoq_config.has_section(plugin_name):
+        if isinstance(
+            self._stoq_config, configparser.ConfigParser
+        ) and self._stoq_config.has_section(plugin_name):
             for opt in self._stoq_config.options(plugin_name):
                 if opt not in plugin_config.options('options'):
                     plugin_config['options'][opt] = self._stoq_config.get(

--- a/stoq/plugin_manager.py
+++ b/stoq/plugin_manager.py
@@ -157,6 +157,8 @@ class StoqPluginManager:
         if isinstance(
             self._stoq_config, configparser.ConfigParser
         ) and self._stoq_config.has_section(plugin_name):
+            if not plugin_config.has_section('options'):
+                plugin_config.add_section('options')
             for opt in self._stoq_config.options(plugin_name):
                 plugin_config['options'][opt] = self._stoq_config.get(plugin_name, opt)
         if self._plugin_opts.get(plugin_name):

--- a/stoq/plugin_manager.py
+++ b/stoq/plugin_manager.py
@@ -151,17 +151,14 @@ class StoqPluginManager:
             )
         _, plugin_class = plugin_classes[0]
         # Plugin configuration order of precendence:
-        # 1) plugin options provided at instatiation of `Stoq()`
-        # 2) `plugin_name.stoq`
-        # 3) plugin configuration in `stoq.cfg`
+        # 1) plugin options provided at instantiation of `Stoq()`
+        # 2) plugin configuration in `stoq.cfg`
+        # 3) `plugin_name.stoq`
         if isinstance(
             self._stoq_config, configparser.ConfigParser
         ) and self._stoq_config.has_section(plugin_name):
             for opt in self._stoq_config.options(plugin_name):
-                if opt not in plugin_config.options('options'):
-                    plugin_config['options'][opt] = self._stoq_config.get(
-                        plugin_name, opt
-                    )
+                plugin_config['options'][opt] = self._stoq_config.get(plugin_name, opt)
         if self._plugin_opts.get(plugin_name):
             plugin_config.read_dict({'options': self._plugin_opts.get(plugin_name)})
         plugin = plugin_class(plugin_config, self._plugin_opts.get(plugin_name))

--- a/stoq/tests/data/stoq.cfg
+++ b/stoq/tests/data/stoq.cfg
@@ -22,3 +22,13 @@ log_dir:
 # What is the maximum size of the provider queue?
 max_queue: 919
 max_recursion: 4
+
+[configurable_worker]
+worker_test_option_bool = True
+worker_test_option_str = Worker Testy McTest Face
+worker_test_option_int = 10
+
+[dummy_connector]
+connector_test_option_bool = False
+connector_test_option_str = Connector Testy McTest Face
+connector_test_option_int = 5


### PR DESCRIPTION
- Allow plugin configurations to be in stoq.cfg
- Merge plugin_opts with plugin config

Plugin configuration order of precedence:
  1) plugin options provided at instantiation of `Stoq(plugin_opts=...)`
  2) plugin configuration in `stoq.cfg`
  3) `plugin_name.stoq`

      Plugin configuration may be added as a new section in `stoq.cfg`. For example, to add `worker_rules` to the `yarascan` plugin in `stoq.cfg`:

```
[yarascan]
worker_rules = /new/path/rules.yar
```

When handling configuration options within a plugin (again, using yarascan as an example) it would change from:

```
if plugin_opts and "worker_rules" in plugin_opts:
        worker_ruleset = plugin_opts["worker_rules"]
elif config.has_option("options", "worker_rules"):
        worker_ruleset = config.get("options", "worker_rules")
else:
        worker_ruleset = None
```

to:

```
worker_ruleset = config.get("options", "worker_rules", fallback=None)
```