### PR TITLE
Parallelizing plugin scans across worker rounds

### DIFF
--- a/stoq/data_classes.py
+++ b/stoq/data_classes.py
@@ -251,18 +251,23 @@ class StoqResponse:
         return repr(self.__dict__)
 
 
-class ExtractedPayload(Payload):
-    """
-    Object to store extracted payloads for further analysis
-    :param content: Raw bytes of extracted payload
-    :param payload_meta: ``PayloadMeta`` object containing metadata about extracted payload
-    >>> src = '/tmp/bad.exe'
-    >>> data = open(src, 'rb').read()
-    >>> extra_data = {'source': src}
-    >>> extracted_meta = PayloadMeta(should_archive=True, extra_data=extra_data)
-    >>> extracted_payload = ExtractedPayload(content=data, payload_meta=extracted_meta)
-    """
-    pass
+class ExtractedPayload:
+    def __init__(
+        self, content: bytes, payload_meta: Optional[PayloadMeta] = None
+    ) -> None:
+        """
+        Object to store extracted payloads for further analysis
+        :param content: Raw bytes of extracted payload
+        :param payload_meta: ``PayloadMeta`` object containing metadata about extracted payload
+        >>> src = '/tmp/bad.exe'
+        >>> data = open(src, 'rb').read()
+        >>> extra_data = {'source': src}
+        >>> extracted_meta = PayloadMeta(should_archive=True, extra_data=extra_data)
+        >>> extracted_payload = ExtractedPayload(content=data, payload_meta=extracted_meta)
+        """
+
+        self.content = content
+        self.payload_meta: PayloadMeta = PayloadMeta() if payload_meta is None else payload_meta
 
 
 class WorkerResponse:

--- a/stoq/data_classes.py
+++ b/stoq/data_classes.py
@@ -276,6 +276,7 @@ class WorkerResponse:
         results: Optional[Dict] = None,
         extracted: Optional[List[ExtractedPayload]] = None,
         errors: Optional[List[Error]] = None,
+        dispatch_to: Optional[List[str]] = None,
     ) -> None:
         """
 
@@ -291,8 +292,9 @@ class WorkerResponse:
 
         """
         self.results = results
-        self.extracted = [] if extracted is None else extracted
+        self.extracted = extracted or []
         self.errors = errors or []
+        self.dispatch_to = dispatch_to or []
 
     def __str__(self) -> str:
         return helpers.dumps(self)

--- a/stoq/data_classes.py
+++ b/stoq/data_classes.py
@@ -251,27 +251,18 @@ class StoqResponse:
         return repr(self.__dict__)
 
 
-class ExtractedPayload:
-    def __init__(
-        self, content: bytes, payload_meta: Optional[PayloadMeta] = None
-    ) -> None:
-        """
-
-        Object to store extracted payloads for further analysis
-
-        :param content: Raw bytes of extracted payload
-        :param payload_meta: ``PayloadMeta`` object containing metadata about extracted payload
-
-        >>> src = '/tmp/bad.exe'
-        >>> data = open(src, 'rb').read()
-        >>> extra_data = {'source': src}
-        >>> extracted_meta = PayloadMeta(should_archive=True, extra_data=extra_data)
-        >>> extracted_payload = ExtractedPayload(content=data, payload_meta=extracted_meta)
-
-        """
-
-        self.content = content
-        self.payload_meta: PayloadMeta = PayloadMeta() if payload_meta is None else payload_meta
+class ExtractedPayload(Payload):
+    """
+    Object to store extracted payloads for further analysis
+    :param content: Raw bytes of extracted payload
+    :param payload_meta: ``PayloadMeta`` object containing metadata about extracted payload
+    >>> src = '/tmp/bad.exe'
+    >>> data = open(src, 'rb').read()
+    >>> extra_data = {'source': src}
+    >>> extracted_meta = PayloadMeta(should_archive=True, extra_data=extra_data)
+    >>> extracted_payload = ExtractedPayload(content=data, payload_meta=extracted_meta)
+    """
+    pass
 
 
 class WorkerResponse:

--- a/stoq/plugins/worker.py
+++ b/stoq/plugins/worker.py
@@ -177,13 +177,27 @@
 
 """
 from abc import abstractmethod
-from typing import Optional
+from configparser import ConfigParser
+from typing import Dict, Optional
 
 from stoq.data_classes import Payload, Request, WorkerResponse
 from stoq.plugins import BasePlugin
 
 
 class WorkerPlugin(BasePlugin):
+    def __init__(self, config: ConfigParser, plugin_opts: Optional[Dict]) -> None:
+        super().__init__(config, plugin_opts)
+
+        required_worker_plugin_names = config.get(
+            'options', 'required_workers', fallback=None
+        )
+        if required_worker_plugin_names:
+            self.required_plugin_names = set(
+                w.strip() for w in required_worker_plugin_names.split(',')
+            )
+        else:
+            self.required_plugin_names = set()
+
     @abstractmethod
     async def scan(
         self, payload: Payload, request: Request

--- a/stoq/tests/data/plugins/dispatcher/conditional_dispatcher/conditional_dispatcher.py
+++ b/stoq/tests/data/plugins/dispatcher/conditional_dispatcher/conditional_dispatcher.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+#   Copyright 2014-2018 PUNCH Cyber Analytics Group
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from typing import Optional
+
+from stoq.data_classes import Payload, DispatcherResponse, Request
+from stoq.plugins import DispatcherPlugin
+
+
+class ConditionalDispatcher(DispatcherPlugin):
+    CONDITIONAL_DISPATCH_WORKER = 'dummy_worker'
+    WORKERS = ['simple_worker']
+
+    async def get_dispatches(
+        self, payload: Payload, request: Request
+    ) -> Optional[DispatcherResponse]:
+        dr = DispatcherResponse()
+        if any(
+            self.CONDITIONAL_DISPATCH_WORKER in request_payload.results.plugins_run['workers']
+            for request_payload in request.payloads
+        ):
+            dr.plugin_names.extend(self.WORKERS)
+        dr.meta['test_key'] = 'Useful metadata info'
+        return dr

--- a/stoq/tests/data/plugins/dispatcher/conditional_dispatcher/conditional_dispatcher.stoq
+++ b/stoq/tests/data/plugins/dispatcher/conditional_dispatcher/conditional_dispatcher.stoq
@@ -1,0 +1,22 @@
+#   Copyright 2014-2015 PUNCH Cyber Analytics Group
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+[Core]
+Name = conditional_dispatcher
+Module = conditional_dispatcher
+
+[Documentation]
+Author = Jeremy Fan
+Version = 0.1
+Description = Conditional stoQ Dispatcher plugin

--- a/stoq/tests/data/stoq.cfg
+++ b/stoq/tests/data/stoq.cfg
@@ -21,7 +21,7 @@
 log_dir:
 # What is the maximum size of the provider queue?
 max_queue: 919
-max_recursion: 4
+max_recursion: 10
 provider_consumers: 50
 
 [configurable_worker]

--- a/stoq/tests/test_core.py
+++ b/stoq/tests/test_core.py
@@ -452,8 +452,8 @@ class TestCore(asynctest.TestCase):
         max_rec_depth = 10  # defined in stoq.cfg
         s = Stoq(base_dir=utils.get_data_dir(), always_dispatch=['extract_payload'])
         response = await s.scan(self.generic_content)
-        self.assertEqual(len(response.results), max_rec_depth + 2)
-        self.assertIn('Max recursion level', response.errors[0].error)
+        self.assertEqual(len(response.results), max_rec_depth + 1)
+        self.assertIn('Final worker round', response.errors[0].error)
 
     async def test_dedup(self):
         # The simple_worker plugin always extracts the same payload

--- a/stoq/tests/test_core.py
+++ b/stoq/tests/test_core.py
@@ -107,7 +107,7 @@ class TestCore(asynctest.TestCase):
         s = Stoq(base_dir=utils.get_data_dir())
         simple_worker = s.load_plugin('simple_worker')
         simple_worker.SHOULD_SCAN = False
-        simple_worker.DISPATCH_TO = ['dummy_worker']
+        simple_worker.EXTRACTED_DISPATCH_TO = ['dummy_worker']
         response = await s.scan(
             self.generic_content, add_start_dispatch=['simple_worker']
         )
@@ -179,7 +179,7 @@ class TestCore(asynctest.TestCase):
     async def test_dispatch_from_worker(self):
         s = Stoq(base_dir=utils.get_data_dir())
         simple_worker = s.load_plugin('simple_worker')
-        simple_worker.DISPATCH_TO = ['extract_payload']
+        simple_worker.EXTRACTED_DISPATCH_TO = ['extract_payload']
         response = await s.scan(
             self.generic_content, add_start_dispatch=['simple_worker']
         )
@@ -187,6 +187,21 @@ class TestCore(asynctest.TestCase):
         self.assertIn('simple_worker', response.results[0].plugins_run['workers'][0])
         self.assertIn('extract_payload', response.results[1].plugins_run['workers'][0])
         self.assertIn('extract_payload', response.results[2].extracted_by)
+
+    async def test_additional_dispatch_from_worker(self):
+        s = Stoq(base_dir=utils.get_data_dir())
+        simple_worker = s.load_plugin('simple_worker')
+        simple_worker.ADDITIONAL_DISPATCH_TO = ['dummy_worker']
+        response = await s.scan(
+            self.generic_content, add_start_dispatch=['simple_worker']
+        )
+
+        self.assertEqual(len(response.results), 2)
+        self.assertCountEqual(
+            response.results[0].plugins_run["workers"],
+            ["simple_worker", "dummy_worker"],
+        )
+        self.assertEqual(len(response.results[1].plugins_run["workers"]), 0)
 
     async def test_dispatch_multiple_plugins(self):
         multi_plugin_content = b'multi-plugin-content'
@@ -237,7 +252,7 @@ class TestCore(asynctest.TestCase):
     async def test_scan_with_required_plugin(self):
         s = Stoq(base_dir=utils.get_data_dir())
         simple_worker = s.load_plugin('simple_worker')
-        simple_worker.DISPATCH_TO = ['simple_worker']
+        simple_worker.EXTRACTED_DISPATCH_TO = ['simple_worker']
         simple_worker.required_plugin_names.add('dummy_worker')
         response = await s.scan(
             self.generic_content, add_start_dispatch=['simple_worker']
@@ -255,7 +270,7 @@ class TestCore(asynctest.TestCase):
     async def test_scan_with_duplicate_extracted_payloads(self):
         s = Stoq(base_dir=utils.get_data_dir())
         simple_worker = s.load_plugin('simple_worker')
-        simple_worker.DISPATCH_TO = ['extract_payload']
+        simple_worker.EXTRACTED_DISPATCH_TO = ['extract_payload']
         simple_worker.EXTRACTED_PAYLOAD = self.generic_content + b'more data'
         extract_worker = s.load_plugin('extract_payload')
         extract_worker.EXTRACTED_PAYLOAD = self.generic_content + b'more data'
@@ -275,7 +290,7 @@ class TestCore(asynctest.TestCase):
     async def test_scan_with_nested_required_plugin(self):
         s = Stoq(base_dir=utils.get_data_dir())
         simple_worker = s.load_plugin('simple_worker')
-        simple_worker.DISPATCH_TO = ['simple_worker']
+        simple_worker.EXTRACTED_DISPATCH_TO = ['simple_worker']
         simple_worker.required_plugin_names.add('dummy_worker')
         dummy_worker = s.load_plugin('dummy_worker')
         dummy_worker.required_plugin_names.add('extract_payload')
@@ -297,7 +312,7 @@ class TestCore(asynctest.TestCase):
     async def test_scan_with_required_plugin_max_depth(self):
         s = Stoq(base_dir=utils.get_data_dir(), max_required_worker_depth=1)
         simple_worker = s.load_plugin('simple_worker')
-        simple_worker.DISPATCH_TO = ['simple_worker']
+        simple_worker.EXTRACTED_DISPATCH_TO = ['simple_worker']
         simple_worker.required_plugin_names.add('dummy_worker')
         dummy_worker = s.load_plugin('dummy_worker')
         dummy_worker.required_plugin_names.add('extract_payload')
@@ -310,7 +325,7 @@ class TestCore(asynctest.TestCase):
     async def test_scan_with_required_plugin_circular_reference(self):
         s = Stoq(base_dir=utils.get_data_dir(), max_required_worker_depth=2000)
         simple_worker = s.load_plugin('simple_worker')
-        simple_worker.DISPATCH_TO = ['simple_worker']
+        simple_worker.EXTRACTED_DISPATCH_TO = ['simple_worker']
         simple_worker.required_plugin_names.add('dummy_worker')
         dummy_worker = s.load_plugin('dummy_worker')
         dummy_worker.required_plugin_names.add('simple_worker')

--- a/stoq/tests/test_core.py
+++ b/stoq/tests/test_core.py
@@ -333,7 +333,7 @@ class TestCore(asynctest.TestCase):
             self.generic_content, add_start_dispatch=['simple_worker']
         )
         self.assertEqual(1, len(response.results))
-        self.assertIn('RecursionError', response.errors[0].error)
+        self.assertIn('Circular', response.errors[0].error)
 
     async def test_source_archive(self):
         s = Stoq(base_dir=utils.get_data_dir(), source_archivers=['simple_archiver'])

--- a/stoq/tests/test_core.py
+++ b/stoq/tests/test_core.py
@@ -14,26 +14,26 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import json
 import asyncio
+import json
 import logging
 import tempfile
-import asynctest  # type: ignore
 
+import asynctest  # type: ignore
+import stoq.tests.utils as utils
 from stoq import Stoq, StoqException
 from stoq.data_classes import (
-    StoqResponse,
-    Request,
-    Payload,
-    PayloadResults,
-    PayloadMeta,
-    RequestMeta,
-    WorkerResponse,
-    DispatcherResponse,
-    DecoratorResponse,
     ArchiverResponse,
+    DecoratorResponse,
+    DispatcherResponse,
+    Payload,
+    PayloadMeta,
+    PayloadResults,
+    Request,
+    RequestMeta,
+    StoqResponse,
+    WorkerResponse,
 )
-import stoq.tests.utils as utils
 
 
 class TestCore(asynctest.TestCase):
@@ -198,10 +198,10 @@ class TestCore(asynctest.TestCase):
 
         self.assertEqual(len(response.results), 2)
         self.assertCountEqual(
-            response.results[0].plugins_run["workers"],
-            ["simple_worker", "dummy_worker"],
+            response.results[0].plugins_run['workers'],
+            ['simple_worker', 'dummy_worker'],
         )
-        self.assertEqual(len(response.results[1].plugins_run["workers"]), 0)
+        self.assertEqual(len(response.results[1].plugins_run['workers']), 0)
 
     async def test_dispatch_multiple_plugins(self):
         multi_plugin_content = b'multi-plugin-content'
@@ -452,7 +452,7 @@ class TestCore(asynctest.TestCase):
         s = Stoq(base_dir=utils.get_data_dir(), source_archivers=['simple_archiver'])
         simple_archiver = s.load_plugin('simple_archiver')
         simple_archiver.RAISE_EXCEPTION = True
-        task = "This will fail"
+        task = 'This will fail'
         with self.assertRaises(Exception) as context:
             await simple_archiver.get(task)
         self.assertTrue('Test exception', context.exception)
@@ -693,30 +693,30 @@ class TestCore(asynctest.TestCase):
         # Construct a fake stoq_response as if it were generated from a file
         # A.zip that contains two files, B.txt and C.zip, where C.zip contains D.txt
         results = [
-            Payload(content=b'', payload_id="A.zip", payload_meta=PayloadMeta()),
+            Payload(content=b'', payload_id='A.zip', payload_meta=PayloadMeta()),
             Payload(
                 content=b'',
-                payload_id="B.txt",
+                payload_id='B.txt',
                 payload_meta=PayloadMeta(),
-                extracted_from="A.zip",
-                extracted_by="fake",
+                extracted_from='A.zip',
+                extracted_by='fake',
             ),
             Payload(
                 content=b'',
-                payload_id="C.zip",
+                payload_id='C.zip',
                 payload_meta=PayloadMeta(),
-                extracted_from="A.zip",
-                extracted_by="fake",
+                extracted_from='A.zip',
+                extracted_by='fake',
             ),
             Payload(
                 content=b'',
-                payload_id="D.txt",
+                payload_id='D.txt',
                 payload_meta=PayloadMeta(),
-                extracted_from="C.zip",
-                extracted_by="fake",
+                extracted_from='C.zip',
+                extracted_by='fake',
             ),
         ]
-        request = Request(request_meta=RequestMeta(extra_data={"check": "me"}))
+        request = Request(request_meta=RequestMeta(extra_data={'check': 'me'}))
         payload_count = 1
         for result in results:
             result.results.workers['fake'] = f'result-{payload_count}'
@@ -725,7 +725,7 @@ class TestCore(asynctest.TestCase):
             payload_count += 1
 
         initial_response = StoqResponse(request)
-        s = Stoq(base_dir=utils.get_data_dir(), decorators=["simple_decorator"])
+        s = Stoq(base_dir=utils.get_data_dir(), decorators=['simple_decorator'])
         all_subresponses = [
             r async for r in s.reconstruct_all_subresponses(initial_response)
         ]
@@ -741,14 +741,14 @@ class TestCore(asynctest.TestCase):
         )
         self.assertEqual(
             [
-                stoq_response.results[0].workers["fake"]
+                stoq_response.results[0].workers['fake']
                 for stoq_response in all_subresponses
             ],
-            ["result-1", "result-2", "result-3", "result-4"],
+            ['result-1', 'result-2', 'result-3', 'result-4'],
         )
         self.assertTrue(
             all(
-                "simple_decorator" in stoq_response.decorators
+                'simple_decorator' in stoq_response.decorators
                 for stoq_response in all_subresponses
             )
         )


### PR DESCRIPTION
This pull request contains the following functionality changes:
- Parallelization is performed across all of the plugins that can run in a given round, instead of parallelizing across all of the plugins to perform on a given payload. This will give us more performance wins. The execution logic of a given worker round is roughly the following:
```
Run all dispatchers on all payloads
Resolve plugin dependencies and eliminate any that have already run
If nothing to do:
  exit
Execute all plugins that can be run
Return extracted payloads, deferred dispatches
```
- Dispatchers run on each payload every round, instead of once per payload. This allows the dispatcher to take advantage of the request state model.
- Worker plugins can specify additional plugins to run on the payload they scan, effectively giving them dispatch capability.
  - With YARA, for example, this allows us to directly scan with YARA and dispatch to other plugins by running YARA once. Otherwise, we would run YARA as a dispatcher, and then immediately run YARA again as a worker plugin.

It also includes the following implementation changes:
- Required plugins are now an attribute on WorkerPlugin. This way, we avoid having to recheck the plugin's configuration in `core.py`.
- When resolving plugin dependencies, we now keep track of the chain of plugin dependencies to detect cycles.
- Archivers run at the very end along with connectors and decorators because we no longer scan a payload to completion at once.
- The default value for `max_recursion` has increased because the average number of worker rounds taken to complete a scan is expected to increase.
- The last commit in this stack reorders public functions to be above private functions, keeps the single quote convention consistent, and renames functions to have clearer meanings.

Lastly, it includes the following testing changes:
- A test dispatcher `conditional_dispatcher.py` was added to test the flow of a dispatcher only dispatching if it sees something in the request state.
- Two test cases were added:
  - `TestCore.test_conditional_dispatch` tests the use case mentioned above.
  - `TestCore.test_additional_dispatch_from_worker` tests worker plugins adding additional dispatches to scanned payloads.