### PR TITLE
Added version info class and logic to base class to include it

### DIFF
--- a/docs/dev/plugin_overview.rst
+++ b/docs/dev/plugin_overview.rst
@@ -185,7 +185,7 @@ can be accessed using ``self.version_info.plugin_version``.  Additionally, ``ext
 dictionary that can be used to store additional version information.  The
 ``VersionInfo.add_version_info()`` method can be used to add extra version information.  This
 is useful for capturing version information of 3rd party tools that the plugin runs.  A developer
-may choose to add version_info to their `WorkerResponse`` results or use a decorator to extract
+may choose to add version_info to their ``WorkerResponse`` results or use a decorator to extract
 version information from plugins that ran during a scan.::
 
     from stoq.helpers import StoqConfigParser

--- a/docs/dev/plugin_overview.rst
+++ b/docs/dev/plugin_overview.rst
@@ -9,7 +9,7 @@ Overview
 `stoQ` is a highly flexible framework because of its ability to leverage plugins for each
 layer of operations. One of the biggest benefits to this approach is that it ensures the
 user is able to quickly and easily pivot to and from different technologies in their stack,
-without having to drastically alter workflow. 
+without having to drastically alter workflow.
 
 For a full listing of all publicly available plugins, check out the `stoQ public plugins <https://github.com/PUNCH-Cyber/stoq-plugins-public>`_ repository.
 
@@ -77,7 +77,7 @@ Plugin .stoq configuration file
 Each plugin must have a ``.stoq`` configuration file. The configuration file resides in
 the same directory as the plugin module. The plugin's configuration file allows for
 configuring a plugin with default or static settings. The configuration file is a standard
-YAML file and is parsed using the ``configparser`` module. The following is an example
+INI file and is parsed using the ``configparser`` module. The following is an example
 plugin configuration file with all *required* fields::
 
     [Core]
@@ -174,6 +174,31 @@ log levels ``debug``, ``info``, ``warning``, ``error``, and ``critical``.::
             self.log.info('Scanning payload now')
 
 
+.. _pluginversioninfo:
+
+Plugin Version info
+*******************
+
+Upon instantiation, plugins will have a ``VersionInfo`` object which can be accessed
+using ``self.version_info``.  The ``VersionInfo`` object has the plugin's version number
+defined in the plugin's configuration file as the member variable ``plugin_version``.
+Additionally, ``extra_info`` is a dictionary that can be used to store additional version
+information.  This is useful for capturing version information of 3rd party tools that the
+plugin runs.  A developer may choose to add version_info to their `WorkerResponse`` results
+or use a decorator to extract version information from plugins that ran during a scan.::
+
+    from stoq.helpers import StoqConfigParser
+    from stoq.plugins import WorkerPlugin
+    from some_3rd_party_tool import get_version
+
+    class RunThirdPartyPlugin(WorkerPlugin):
+        def __init__(self, config: StoqConfigParser) -> None:
+            super().__init__(config)
+            self.version_info.add_version_info(
+                {'3rdPartyToolVersion': get_version()}
+            )
+
+
 .. _pluginerrors:
 
 Errors
@@ -184,7 +209,7 @@ consistent and standardized error message handling across the framework. All plu
 classes are capable of handling errors, except for the ``ConnectorPlugin`` class. The
 following is an example of adding a error to a ``WorkerResponse``.::
 
-    
+
     from typing import Optional
     from stoq.plugins import WorkerPlugin
     from stoq import Error, Payload, Request, WorkerResponse
@@ -196,8 +221,8 @@ following is an example of adding a error to a ``WorkerResponse``.::
             errors: List[Error] = []
             errors.append(
                 Error(
-                    error='This is an error message that will be in StoqResponse', 
-                    plugin_name=self.plugin_name, 
+                    error='This is an error message that will be in StoqResponse',
+                    plugin_name=self.plugin_name,
                     payload_id=payload.results.payload_id
                 )
             )

--- a/docs/dev/plugin_overview.rst
+++ b/docs/dev/plugin_overview.rst
@@ -185,8 +185,8 @@ can be accessed using ``self.version_info.plugin_version``.  Additionally, ``ext
 dictionary that can be used to store additional version information.  The
 ``VersionInfo.add_version_info()`` method can be used to add extra version information.  This
 is useful for capturing version information of 3rd party tools that the plugin runs.  A developer
-may choose to add version_info to their ``WorkerResponse`` results or use a decorator to extract
-version information from plugins that ran during a scan.::
+may choose to add ``self.version_info`` to their ``WorkerResponse`` results or use a decorator to
+extract version information from plugins that ran during a scan.::
 
     from stoq.helpers import StoqConfigParser
     from stoq.plugins import WorkerPlugin

--- a/docs/dev/plugin_overview.rst
+++ b/docs/dev/plugin_overview.rst
@@ -174,32 +174,6 @@ log levels ``debug``, ``info``, ``warning``, ``error``, and ``critical``.::
             self.log.info('Scanning payload now')
 
 
-.. _versioninfo:
-
-Version Info
-************
-
-Upon instantiation, plugins will have a ``VersionInfo`` object which can be accessed
-using ``self.version_info``.  The version number defined in the plugin's configuration file
-can be accessed using ``self.version_info.plugin_version``.  Additionally, ``extra_info`` is a
-dictionary that can be used to store additional version information.  The
-``VersionInfo.add_version_info()`` method can be used to add extra version information.  This
-is useful for capturing version information of 3rd party tools that the plugin runs.  A developer
-may choose to add ``self.version_info`` to their ``WorkerResponse`` results or use a decorator to
-extract version information from plugins that ran during a scan.::
-
-    from stoq.helpers import StoqConfigParser
-    from stoq.plugins import WorkerPlugin
-    from some_3rd_party_tool import get_version
-
-    class RunThirdPartyPlugin(WorkerPlugin):
-        def __init__(self, config: StoqConfigParser) -> None:
-            super().__init__(config)
-            self.version_info.add_version_info(
-                {'3rdPartyToolVersion': get_version()}
-            )
-
-
 .. _pluginerrors:
 
 Errors

--- a/docs/dev/plugin_overview.rst
+++ b/docs/dev/plugin_overview.rst
@@ -174,18 +174,19 @@ log levels ``debug``, ``info``, ``warning``, ``error``, and ``critical``.::
             self.log.info('Scanning payload now')
 
 
-.. _pluginversioninfo:
+.. _versioninfo:
 
-Plugin Version info
-*******************
+Version Info
+************
 
 Upon instantiation, plugins will have a ``VersionInfo`` object which can be accessed
-using ``self.version_info``.  The ``VersionInfo`` object has the plugin's version number
-defined in the plugin's configuration file as the member variable ``plugin_version``.
-Additionally, ``extra_info`` is a dictionary that can be used to store additional version
-information.  This is useful for capturing version information of 3rd party tools that the
-plugin runs.  A developer may choose to add version_info to their `WorkerResponse`` results
-or use a decorator to extract version information from plugins that ran during a scan.::
+using ``self.version_info``.  The version number defined in the plugin's configuration file
+can be accessed using ``self.version_info.plugin_version``.  Additionally, ``extra_info`` is a
+dictionary that can be used to store additional version information.  The
+``VersionInfo.add_version_info()`` method can be used to add extra version information.  This
+is useful for capturing version information of 3rd party tools that the plugin runs.  A developer
+may choose to add version_info to their `WorkerResponse`` results or use a decorator to extract
+version information from plugins that ran during a scan.::
 
     from stoq.helpers import StoqConfigParser
     from stoq.plugins import WorkerPlugin

--- a/stoq/data_classes.py
+++ b/stoq/data_classes.py
@@ -21,16 +21,17 @@ from typing import Dict, List, Optional, DefaultDict, Union
 
 import stoq.helpers as helpers
 
+
 class VersionInfo:
-    def __init__(self, plugin_version: str) -> None:
+    def __init__(self, plugin_version: Optional[str] = None) -> None:
         """
 
-        Object for keeping track of version information of the plugin that was run
+        Object for keeping track of version information in worker plugins
 
-        :param plugin_version: Version of the stoQ plugin
+        :param plugin_version: Version of the stoQ worker plugin
 
         """
-        self.plugin_version = plugin_version
+        self.plugin_version = plugin_version or ''
         self.extra_info: Dict = {}
 
     def add_version_info(self, extra_info: Dict) -> None:
@@ -336,6 +337,7 @@ class WorkerResponse:
         self,
         results: Optional[Dict] = None,
         extracted: Optional[List[ExtractedPayload]] = None,
+        version_info: Optional[VersionInfo] = None,
         errors: Optional[List[Error]] = None,
         dispatch_to: Optional[List[str]] = None,
     ) -> None:
@@ -345,7 +347,9 @@ class WorkerResponse:
 
         :param results: Results from worker scan
         :param extracted: ``ExtractedPayload`` objects of extracted payloads from scan
+        :param version_info: ``VersionInfo`` object containing plugin versioning information
         :param errors: Errors that occurred
+        :param dispatch_to: List of additional worker plugins that payload should be dispatched to
 
         >>> from stoq import WorkerResponse, ExtractedPayload
         >>> results = {'is_bad': True, 'filetype': 'executable'}
@@ -355,6 +359,7 @@ class WorkerResponse:
         """
         self.results = results
         self.extracted = extracted or []
+        self.version_info = version_info or VersionInfo()
         self.errors = errors or []
         self.dispatch_to = dispatch_to or []
 

--- a/stoq/data_classes.py
+++ b/stoq/data_classes.py
@@ -17,9 +17,24 @@
 import uuid
 from copy import deepcopy
 from datetime import datetime
-from typing import Dict, List, Optional, DefaultDict, Union
+from typing import Dict, List, Optional, DefaultDict, Union, Any
 
 import stoq.helpers as helpers
+
+class VersionInfo:
+    def __init__(self, stoq_plugin_version: str) -> None:
+        """
+
+        Object for keeping track of version information of the plugin that was run
+
+        :param stoq_plugin_version: Version of the plugin
+
+        """
+        self.stoq_plugin_version = stoq_plugin_version
+        self.extra_info = None
+
+    def add_extra_version_info(self, extra_info: Any) -> None:
+        self.extra_info = extra_info
 
 
 class Error:
@@ -42,7 +57,7 @@ class Error:
         >>> payload = Payload(b'test bytes')
         >>> err = Error(
         ...     error='This is our error message',
-        ...     plugin_name='test_plugin', 
+        ...     plugin_name='test_plugin',
         ...     payload_id=payload.results.payload_id
         ... )
         >>> errors.append(err)
@@ -220,7 +235,7 @@ class Request:
     ):
         """
 
-        Object that contains the state of a ``Stoq`` scan. This object is accessible within 
+        Object that contains the state of a ``Stoq`` scan. This object is accessible within
         all archiver, dispatcher, and worker plugins.
 
         :param payloads: All payloads that are being processed, to include extracted payloads

--- a/stoq/data_classes.py
+++ b/stoq/data_classes.py
@@ -17,24 +17,30 @@
 import uuid
 from copy import deepcopy
 from datetime import datetime
-from typing import Dict, List, Optional, DefaultDict, Union, Any
+from typing import Dict, List, Optional, DefaultDict, Union
 
 import stoq.helpers as helpers
 
 class VersionInfo:
-    def __init__(self, stoq_plugin_version: str) -> None:
+    def __init__(self, plugin_version: str) -> None:
         """
 
         Object for keeping track of version information of the plugin that was run
 
-        :param stoq_plugin_version: Version of the plugin
+        :param plugin_version: Version of the stoQ plugin
 
         """
-        self.stoq_plugin_version = stoq_plugin_version
-        self.extra_info = None
+        self.plugin_version = plugin_version
+        self.extra_info: Dict = {}
 
-    def add_extra_version_info(self, extra_info: Any) -> None:
-        self.extra_info = extra_info
+    def add_version_info(self, extra_info: Dict) -> None:
+        self.extra_info.update(extra_info)
+
+    def __str__(self) -> str:
+        return helpers.dumps(self)
+
+    def __repr__(self):
+        return repr(self.__dict__)
 
 
 class Error:

--- a/stoq/plugins/base.py
+++ b/stoq/plugins/base.py
@@ -19,7 +19,6 @@ from abc import ABC
 from typing import Dict, Optional
 
 from stoq.helpers import StoqConfigParser
-from stoq.data_classes import VersionInfo
 
 
 class BasePlugin(ABC):
@@ -31,4 +30,3 @@ class BasePlugin(ABC):
         self.__website__ = config.get('Documentation', 'Website', fallback='')
         self.__description__ = config.get('Documentation', 'Description', fallback='')
         self.log = logging.getLogger(f'stoq.{self.plugin_name}')
-        self.version_info = VersionInfo(self.__version__)

--- a/stoq/plugins/worker.py
+++ b/stoq/plugins/worker.py
@@ -129,6 +129,44 @@
                 response = {'worker_results': f'is_bad: {is_bad}'}
                 return WorkerResponse(response)
 
+    Version Information
+    -------------------
+
+    Worker plugin version information can be collected for later use, such as
+    dispatching or within a decorator plugin. The ``VersionInfo`` object can
+    contain the version information of the worker plugin itself, as well as 
+    additional version information from 3rd party tools used by the plugin.
+
+    All version information is available in the ``WorkerResponse`` object,
+    and can be accessed at a later time for the duration of the ``Request``.
+
+
+    ::
+
+        from typing import Dict, List, Optional
+
+        from stoq.plugins import WorkerPlugin
+        from stoq.helpers import StoqConfigParser
+        from stoq.data_classes import (
+            Payload,
+            Request,
+            WorkerResponse,
+            VersionInfo
+        )
+
+
+        class ExampleWorker(WorkerPlugin):
+            def __init__(self, config: StoqConfigParser) -> None:
+                super().__init__(config)
+
+            async def scan(
+                self, payload: Payload, request: Request
+            ) -> Optional[WorkerResponse]:
+                version_info = VersionInfo(self.__version__)
+                version_info.add_version_info({'3rd_party_tool': 'v1.0'})
+                response = {'worker_results': 'something useful'}
+                return WorkerResponse(response, version_info=version_info)
+
 
     Extracted Payloads
     ------------------

--- a/stoq/tests/data/plugins/worker/version_info_plugin/version_info_plugin.py
+++ b/stoq/tests/data/plugins/worker/version_info_plugin/version_info_plugin.py
@@ -23,7 +23,7 @@ from stoq.helpers import StoqConfigParser
 class VersionInfoPlugin(WorkerPlugin):
     def __init__(self, config: StoqConfigParser) -> None:
         super().__init__(config)
-        self.version_info.add_extra_version_info({'3rdPartyVersion':'0.2'})
+        self.version_info.add_version_info({'3rdPartyVersion':'0.2'})
     async def scan(
         self, payload: Payload, request: Request
     ) -> Optional[WorkerResponse]:

--- a/stoq/tests/data/plugins/worker/version_info_plugin/version_info_plugin.py
+++ b/stoq/tests/data/plugins/worker/version_info_plugin/version_info_plugin.py
@@ -14,21 +14,17 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import logging
-from abc import ABC
-from typing import Dict, Optional
+from typing import Optional
 
+from stoq.data_classes import Payload, Request, WorkerResponse
+from stoq.plugins import WorkerPlugin
 from stoq.helpers import StoqConfigParser
-from stoq.data_classes import VersionInfo
 
-
-class BasePlugin(ABC):
+class VersionInfoPlugin(WorkerPlugin):
     def __init__(self, config: StoqConfigParser) -> None:
-        self.config = config
-        self.plugin_name = config.get('Core', 'Name', fallback=self.__class__.__name__)
-        self.__author__ = config.get('Documentation', 'Author', fallback='')
-        self.__version__ = config.get('Documentation', 'Version', fallback='')
-        self.__website__ = config.get('Documentation', 'Website', fallback='')
-        self.__description__ = config.get('Documentation', 'Description', fallback='')
-        self.log = logging.getLogger(f'stoq.{self.plugin_name}')
-        self.version_info = VersionInfo(self.__version__)
+        super().__init__(config)
+        self.version_info.add_extra_version_info({'3rdPartyVersion':'0.2'})
+    async def scan(
+        self, payload: Payload, request: Request
+    ) -> Optional[WorkerResponse]:
+        return None

--- a/stoq/tests/data/plugins/worker/version_info_plugin/version_info_plugin.py
+++ b/stoq/tests/data/plugins/worker/version_info_plugin/version_info_plugin.py
@@ -16,15 +16,20 @@
 
 from typing import Optional
 
-from stoq.data_classes import Payload, Request, WorkerResponse
 from stoq.plugins import WorkerPlugin
 from stoq.helpers import StoqConfigParser
+from stoq.data_classes import Payload, Request, WorkerResponse, VersionInfo
+
 
 class VersionInfoPlugin(WorkerPlugin):
     def __init__(self, config: StoqConfigParser) -> None:
         super().__init__(config)
-        self.version_info.add_version_info({'3rdPartyVersion':'0.2'})
-    async def scan(
-        self, payload: Payload, request: Request
-    ) -> Optional[WorkerResponse]:
-        return None
+        self.INVALID_VERSION = False
+
+    async def scan(self, payload: Payload, request: Request) -> WorkerResponse:
+        version_info = VersionInfo(self.__version__)
+        if self.INVALID_VERSION:
+            version_info.add_version_info('invalid version info')
+        else:
+            version_info.add_version_info({'3rdPartyVersion': '0.2'})
+        return WorkerResponse(version_info=version_info)

--- a/stoq/tests/data/plugins/worker/version_info_plugin/version_info_plugin.stoq
+++ b/stoq/tests/data/plugins/worker/version_info_plugin/version_info_plugin.stoq
@@ -1,0 +1,23 @@
+#   Copyright 2014-2017 PUNCH Cyber Analytics Group
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+[Core]
+Name = version_info_plugin
+Module = version_info_plugin
+
+[Documentation]
+Author = Yair Treister
+Version = 0.1
+Website = https://github.com/PUNCH-Cyber/stoq-plugins-public
+Description = Dummy stoQ Worker plugin with extra version info

--- a/stoq/tests/test_plugin_manager.py
+++ b/stoq/tests/test_plugin_manager.py
@@ -68,8 +68,17 @@ class TestPluginManager(unittest.TestCase):
         pm = StoqPluginManager([utils.get_plugins_dir()])
         version_info_plugin = pm.load_plugin('version_info_plugin')
         self.assertTrue(isinstance(version_info_plugin.version_info, VersionInfo))
-        self.assertEqual('0.1', version_info_plugin.version_info.stoq_plugin_version)
-        self.assertEqual({'3rdPartyVersion':'0.2'}, version_info_plugin.version_info.extra_info)
+        self.assertEqual('0.1', version_info_plugin.version_info.plugin_version)
+        self.assertEqual(
+            {'3rdPartyVersion': '0.2'}, version_info_plugin.version_info.extra_info
+        )
+
+    def test_version_info_invalid_add_type(self):
+        pm = StoqPluginManager([utils.get_plugins_dir()])
+        version_info_plugin = pm.load_plugin('version_info_plugin')
+        self.assertTrue(isinstance(version_info_plugin.version_info, VersionInfo))
+        with self.assertRaises(ValueError):
+            version_info_plugin.version_info.add_version_info('invalid_version_info_type')
 
     def test_plugin_missing_objects(self):
         pm = StoqPluginManager([utils.get_invalid_plugins_dir()])

--- a/stoq/tests/test_plugin_manager.py
+++ b/stoq/tests/test_plugin_manager.py
@@ -21,7 +21,7 @@ from typing import Optional
 
 
 from stoq import Stoq, StoqException, StoqPluginNotFound
-from stoq.data_classes import Payload, WorkerResponse, Request
+from stoq.data_classes import Payload, WorkerResponse, Request, VersionInfo
 from stoq.plugin_manager import StoqPluginManager
 from stoq.plugins import WorkerPlugin
 import stoq.tests.utils as utils
@@ -63,6 +63,13 @@ class TestPluginManager(unittest.TestCase):
             simple_worker.__website__,
         )
         self.assertEqual('Simple stoQ Worker plugin', simple_worker.__description__)
+
+    def test_version_info(self):
+        pm = StoqPluginManager([utils.get_plugins_dir()])
+        version_info_plugin = pm.load_plugin('version_info_plugin')
+        self.assertTrue(isinstance(version_info_plugin.version_info, VersionInfo))
+        self.assertEqual('0.1', version_info_plugin.version_info.stoq_plugin_version)
+        self.assertEqual({'3rdPartyVersion':'0.2'}, version_info_plugin.version_info.extra_info)
 
     def test_plugin_missing_objects(self):
         pm = StoqPluginManager([utils.get_invalid_plugins_dir()])

--- a/stoq/tests/test_plugin_manager.py
+++ b/stoq/tests/test_plugin_manager.py
@@ -64,22 +64,6 @@ class TestPluginManager(unittest.TestCase):
         )
         self.assertEqual('Simple stoQ Worker plugin', simple_worker.__description__)
 
-    def test_version_info(self):
-        pm = StoqPluginManager([utils.get_plugins_dir()])
-        version_info_plugin = pm.load_plugin('version_info_plugin')
-        self.assertTrue(isinstance(version_info_plugin.version_info, VersionInfo))
-        self.assertEqual('0.1', version_info_plugin.version_info.plugin_version)
-        self.assertEqual(
-            {'3rdPartyVersion': '0.2'}, version_info_plugin.version_info.extra_info
-        )
-
-    def test_version_info_invalid_add_type(self):
-        pm = StoqPluginManager([utils.get_plugins_dir()])
-        version_info_plugin = pm.load_plugin('version_info_plugin')
-        self.assertTrue(isinstance(version_info_plugin.version_info, VersionInfo))
-        with self.assertRaises(ValueError):
-            version_info_plugin.version_info.add_version_info('invalid_version_info_type')
-
     def test_plugin_missing_objects(self):
         pm = StoqPluginManager([utils.get_invalid_plugins_dir()])
         worker = pm.load_plugin('missing_config_objects')


### PR DESCRIPTION
This is what we discussed in issue #122.  If this got merged as-is, you would be able to add 3rd party version information to plugins.

As an example, you could add something like this to the exif plugin:
```python
class ExifToolPlugin(WorkerPlugin):
    def __init__(self, config: StoqConfigParser) -> None:
        super().__init__(config)
        self.bin = config.get('options', 'bin', fallback='exiftool')
        # Get and add exiftool version information
        output = run([self.bin, '-ver'], stdout=PIPE)
        version = output.stdout.rstrip()
        self.version_info.add_extra_version_info({'ExifToolVersion': version})
```
Other plugins could have more complex version info.  For example OPSWAT Metadefender could have last definition update times for each scanner in addition to the version of Metadefender used.