### PR TITLE
Fix getjson

### DIFF
--- a/stoq/helpers/__init__.py
+++ b/stoq/helpers/__init__.py
@@ -15,6 +15,7 @@
 #   limitations under the License.
 
 import json
+import ast
 import hashlib
 import datetime
 import traceback
@@ -57,7 +58,7 @@ class StoqConfigParser(ConfigParser):
 
         """
         try:
-            value = json.loads(self.get(section, option, fallback=kwargs.get('fallback', '{}')))
+            value = ast.literal_eval(self.get(section, option, fallback=kwargs.get('fallback', '{}')))
         except Exception as err:
             raise StoqException(f"Unable to parse [{section}] -> {option} as JSON. Error: {err}")
         return value

--- a/stoq/tests/data/config.cfg
+++ b/stoq/tests/data/config.cfg
@@ -1,9 +1,0 @@
-[options]
-list = [
-    "item1",
-    "item2"
-    ]
-dict = {
-    "key": "value"
-    }
-invalid = {"key":}

--- a/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.py
+++ b/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.py
@@ -31,3 +31,15 @@ class ConfigurableWorker(WorkerPlugin):
 
     def get_crazy_runtime_option(self):
         return self.config.getint('options', 'crazy_runtime_option')
+
+    def getjson_list_option(self):
+        return self.config.getjson('options', 'list')
+
+    def getjson_dict_option(self):
+        return self.config.getjson('options', 'dict')
+
+    def getjson_invalid_option(self):
+        return self.config.getjson('options', 'invalid')
+
+    def getjson_doesnotexist_option(self):
+        return self.config.getjson('options', 'doesnotexist')

--- a/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.py
+++ b/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.py
@@ -32,14 +32,5 @@ class ConfigurableWorker(WorkerPlugin):
     def get_crazy_runtime_option(self):
         return self.config.getint('options', 'crazy_runtime_option')
 
-    def getjson_list_option(self):
-        return self.config.getjson('options', 'list')
-
-    def getjson_dict_option(self):
-        return self.config.getjson('options', 'dict')
-
-    def getjson_invalid_option(self):
-        return self.config.getjson('options', 'invalid')
-
-    def getjson_doesnotexist_option(self):
-        return self.config.getjson('options', 'doesnotexist')
+    def getjson_option(self, option):
+        return self.config.getjson('options', option)

--- a/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.stoq
+++ b/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.stoq
@@ -24,3 +24,13 @@ Description = Configurable stoQ Worker plugin
 
 [options]
 important_option = cybercybercyber
+
+# Tests for getjson feature
+list = [
+    "item1",
+    "item2"
+    ]
+dict = {
+    "key": "value"
+    }
+invalid = {"key":}

--- a/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.stoq
+++ b/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.stoq
@@ -34,3 +34,9 @@ dict = {
     "key": "value"
     }
 invalid = {"key":}
+sq_dict: {
+    "bar'foo": "value"
+    }
+dq_dict: {
+    'bar"foo': "value"
+    }

--- a/stoq/tests/test_helpers.py
+++ b/stoq/tests/test_helpers.py
@@ -17,8 +17,6 @@
 import unittest
 from datetime import datetime
 from collections import defaultdict
-from stoq.exceptions import StoqException
-from os.path import join
 import stoq.helpers as helpers
 
 
@@ -83,24 +81,6 @@ class TestHelpers(unittest.TestCase):
             h,
             '015e6d23e760f612cca616c54f110cb12dd54213f1e046c7607081372402eff4936b379296ed549236020afb37bd3e728a044a4243754f095498c98bc24f77e0',
         )
-
-    def test_stoq_config_getjson(self):
-        config = helpers.StoqConfigParser()
-        config.read(join('stoq', 'tests', 'data', 'config.cfg'))
-
-        # List
-        self.assertEqual(config.getjson('options', 'list'), ['item1', 'item2'])
-
-        # Dictionary
-        self.assertEqual(config.getjson('options', 'dict'), {'key':'value'})
-
-        # Invalid JSON
-        with self.assertRaises(StoqException) as exc:
-            config.getjson('options', 'invalid')
-        self.assertTrue('Unable to parse [options] -> invalid as JSON.' in str(exc.exception))
-
-        # Fallback
-        self.assertEqual(config.getjson('options', 'doesnotexist'), {})
 
 class ClassWithAttrs:
     def __init__(self):

--- a/stoq/tests/test_plugin_manager.py
+++ b/stoq/tests/test_plugin_manager.py
@@ -129,13 +129,16 @@ class TestPluginManager(unittest.TestCase):
         self.assertEqual(plugin.get_important_option(), 'cybercybercyber')
 
         # Test StoqConfigParser.getjson reading from configuration file
-        self.assertEqual(plugin.getjson_list_option(), ['item1', 'item2'])
-        self.assertEqual(plugin.getjson_dict_option(), {'key':'value'})
+        self.assertEqual(plugin.getjson_option('list'), ['item1', 'item2'])
+        self.assertEqual(plugin.getjson_option('dict'), {'key':'value'})
+        self.assertEqual(plugin.getjson_option('sq_dict'), {"bar'foo": "value"})
+        self.assertEqual(plugin.getjson_option('dq_dict'), {'bar"foo': "value"})
         with self.assertRaises(StoqException) as exc:
-            plugin.getjson_invalid_option()
+            plugin.getjson_option('invalid')
         self.assertTrue('Unable to parse [options] -> invalid as JSON.' in str(exc.exception))
+
         # Test fallback
-        self.assertEqual(plugin.getjson_doesnotexist_option(), {})
+        self.assertEqual(plugin.getjson_option('doesnotexist'), {})
 
     def test_plugin_opts(self):
         pm = StoqPluginManager(
@@ -144,17 +147,21 @@ class TestPluginManager(unittest.TestCase):
                 'crazy_runtime_option': 16,
                 'list': ['item3', 'item4'],
                 'dict': {'key1': 'value1'},
-                'invalid':''
+                'invalid':'',
+                'sq_dict': {"foo'bar": "value"},
+                'dq_dict': {'foo"bar': "value"}
                 }},
         )
         plugin = pm.load_plugin('configurable_worker')
         self.assertEqual(plugin.get_crazy_runtime_option(), 16)
 
         # Test StoqConfigParser.getjson reading from plugin_opts
-        self.assertEqual(plugin.getjson_list_option(), ['item3', 'item4'])
-        self.assertEqual(plugin.getjson_dict_option(), {'key1':'value1'})
+        self.assertEqual(plugin.getjson_option('list'), ['item3', 'item4'])
+        self.assertEqual(plugin.getjson_option('dict'), {'key1':'value1'})
+        self.assertEqual(plugin.getjson_option('sq_dict'), {"foo'bar": "value"})
+        self.assertEqual(plugin.getjson_option('dq_dict'), {'foo"bar': "value"})
         with self.assertRaises(StoqException) as exc:
-            plugin.getjson_invalid_option()
+            plugin.getjson_option('invalid')
         self.assertTrue('Unable to parse [options] -> invalid as JSON.' in str(exc.exception))
 
     def test_plugin_opts_from_stoq_cfg(self):

--- a/stoq/tests/test_plugin_manager.py
+++ b/stoq/tests/test_plugin_manager.py
@@ -128,13 +128,34 @@ class TestPluginManager(unittest.TestCase):
         plugin = pm.load_plugin('configurable_worker')
         self.assertEqual(plugin.get_important_option(), 'cybercybercyber')
 
+        # Test StoqConfigParser.getjson reading from configuration file
+        self.assertEqual(plugin.getjson_list_option(), ['item1', 'item2'])
+        self.assertEqual(plugin.getjson_dict_option(), {'key':'value'})
+        with self.assertRaises(StoqException) as exc:
+            plugin.getjson_invalid_option()
+        self.assertTrue('Unable to parse [options] -> invalid as JSON.' in str(exc.exception))
+        # Test fallback
+        self.assertEqual(plugin.getjson_doesnotexist_option(), {})
+
     def test_plugin_opts(self):
         pm = StoqPluginManager(
             [utils.get_plugins_dir()],
-            {'configurable_worker': {'crazy_runtime_option': 16}},
+            {'configurable_worker': {
+                'crazy_runtime_option': 16,
+                'list': ['item3', 'item4'],
+                'dict': {'key1': 'value1'},
+                'invalid':''
+                }},
         )
         plugin = pm.load_plugin('configurable_worker')
         self.assertEqual(plugin.get_crazy_runtime_option(), 16)
+
+        # Test StoqConfigParser.getjson reading from plugin_opts
+        self.assertEqual(plugin.getjson_list_option(), ['item3', 'item4'])
+        self.assertEqual(plugin.getjson_dict_option(), {'key1':'value1'})
+        with self.assertRaises(StoqException) as exc:
+            plugin.getjson_invalid_option()
+        self.assertTrue('Unable to parse [options] -> invalid as JSON.' in str(exc.exception))
 
     def test_plugin_opts_from_stoq_cfg(self):
         s = Stoq(base_dir=utils.get_data_dir())


### PR DESCRIPTION
getjson worked fine when the options were in the configuration file, but failed when options were specified via plugin_opts.  This was since Python does not store dictionaries with double quotes, and `json.loads` failed to properly process a string.  I replaced with ast.lieral_eval and beefed up the tests to make sure it works for both config files and plugin_opts