### PR TITLE
Fix getjson issues with plugin_opts

### DIFF
--- a/stoq/helpers/__init__.py
+++ b/stoq/helpers/__init__.py
@@ -52,16 +52,16 @@ class StoqConfigParser(ConfigParser):
             return value
         return set(o.strip() for o in value.split(',') if o)
 
-    def getjson(self, section, option, *args, **kwargs) -> Any:
+    def getjson(self, section, option, *args, **kwargs) -> Union[Dict, List]:
         """
         Create a Python object from `ConfigParser` option using JSON syntax
+        no fallback returns an empty dictionary
 
         """
-        try:
-            value = ast.literal_eval(self.get(section, option, fallback=kwargs.get('fallback', '{}')))
-        except Exception as err:
-            raise StoqException(f"Unable to parse [{section}] -> {option} as JSON. Error: {err}")
-        return value
+        value = self.get(section, option, fallback=kwargs.get('fallback', {}))
+        if isinstance(value, dict):
+            return value
+        return ast.literal_eval(value)
 
 class JsonComplexEncoder(json.JSONEncoder):
     """

--- a/stoq/helpers/__init__.py
+++ b/stoq/helpers/__init__.py
@@ -15,7 +15,6 @@
 #   limitations under the License.
 
 import json
-import ast
 import hashlib
 import datetime
 import traceback

--- a/stoq/helpers/__init__.py
+++ b/stoq/helpers/__init__.py
@@ -59,9 +59,9 @@ class StoqConfigParser(ConfigParser):
 
         """
         value = self.get(section, option, fallback=kwargs.get('fallback', {}))
-        if isinstance(value, dict):
+        if isinstance(value, (dict, list)):
             return value
-        return ast.literal_eval(value)
+        return json.loads(value)
 
 class JsonComplexEncoder(json.JSONEncoder):
     """

--- a/stoq/helpers/__init__.py
+++ b/stoq/helpers/__init__.py
@@ -15,6 +15,7 @@
 #   limitations under the License.
 
 import json
+import ast
 import hashlib
 import datetime
 import traceback
@@ -57,7 +58,7 @@ class StoqConfigParser(ConfigParser):
 
         """
         try:
-            value = json.loads(self.get(section, option, fallback=kwargs.get('fallback', '{}')))
+            value = ast.literal_eval(self.get(section, option, fallback=kwargs.get('fallback', '{}')))
         except Exception as err:
             raise StoqException(f"Unable to parse [{section}] -> {option} as JSON. Error: {err}")
         return value

--- a/stoq/tests/data/config.cfg
+++ b/stoq/tests/data/config.cfg
@@ -1,9 +1,0 @@
-[options]
-list = [
-    "item1",
-    "item2"
-    ]
-dict = {
-    "key": "value"
-    }
-invalid = {"key":}

--- a/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.py
+++ b/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.py
@@ -31,3 +31,6 @@ class ConfigurableWorker(WorkerPlugin):
 
     def get_crazy_runtime_option(self):
         return self.config.getint('options', 'crazy_runtime_option')
+
+    def getjson_option(self, option):
+        return self.config.getjson('options', option)

--- a/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.stoq
+++ b/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.stoq
@@ -24,3 +24,19 @@ Description = Configurable stoQ Worker plugin
 
 [options]
 important_option = cybercybercyber
+
+# Tests for getjson feature
+list = [
+    "item1",
+    "item2"
+    ]
+dict = {
+    "key": "value"
+    }
+invalid = {"key":}
+sq_dict: {
+    "bar'foo": "value"
+    }
+dq_dict: {
+    'bar"foo': "value"
+    }

--- a/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.stoq
+++ b/stoq/tests/data/plugins/worker/configurable_worker/configurable_worker.stoq
@@ -37,6 +37,3 @@ invalid = {"key":}
 sq_dict: {
     "bar'foo": "value"
     }
-dq_dict: {
-    'bar"foo': "value"
-    }

--- a/stoq/tests/test_helpers.py
+++ b/stoq/tests/test_helpers.py
@@ -17,8 +17,6 @@
 import unittest
 from datetime import datetime
 from collections import defaultdict
-from stoq.exceptions import StoqException
-from os.path import join
 import stoq.helpers as helpers
 
 
@@ -83,24 +81,6 @@ class TestHelpers(unittest.TestCase):
             h,
             '015e6d23e760f612cca616c54f110cb12dd54213f1e046c7607081372402eff4936b379296ed549236020afb37bd3e728a044a4243754f095498c98bc24f77e0',
         )
-
-    def test_stoq_config_getjson(self):
-        config = helpers.StoqConfigParser()
-        config.read(join('stoq', 'tests', 'data', 'config.cfg'))
-
-        # List
-        self.assertEqual(config.getjson('options', 'list'), ['item1', 'item2'])
-
-        # Dictionary
-        self.assertEqual(config.getjson('options', 'dict'), {'key':'value'})
-
-        # Invalid JSON
-        with self.assertRaises(StoqException) as exc:
-            config.getjson('options', 'invalid')
-        self.assertTrue('Unable to parse [options] -> invalid as JSON.' in str(exc.exception))
-
-        # Fallback
-        self.assertEqual(config.getjson('options', 'doesnotexist'), {})
 
 class ClassWithAttrs:
     def __init__(self):

--- a/stoq/tests/test_plugin_manager.py
+++ b/stoq/tests/test_plugin_manager.py
@@ -18,6 +18,7 @@
 import logging
 import unittest
 from typing import Optional
+import json
 
 
 from stoq import Stoq, StoqException, StoqPluginNotFound
@@ -132,8 +133,7 @@ class TestPluginManager(unittest.TestCase):
         self.assertEqual(plugin.getjson_option('list'), ['item1', 'item2'])
         self.assertEqual(plugin.getjson_option('dict'), {'key':'value'})
         self.assertEqual(plugin.getjson_option('sq_dict'), {"bar'foo": "value"})
-        self.assertEqual(plugin.getjson_option('dq_dict'), {'bar"foo': "value"})
-        with self.assertRaises(SyntaxError) as exc:
+        with self.assertRaises(json.decoder.JSONDecodeError) as exc:
             plugin.getjson_option('invalid')
 
         # Test fallback
@@ -144,11 +144,11 @@ class TestPluginManager(unittest.TestCase):
             [utils.get_plugins_dir()],
             {'configurable_worker': {
                 'crazy_runtime_option': 16,
-                'list': ['item3', 'item4'],
-                'dict': {'key1': 'value1'},
-                'invalid':'',
-                'sq_dict': {"foo'bar": "value"},
-                'dq_dict': {'foo"bar': "value"}
+                'list': json.dumps(['item3', 'item4']),
+                'dict': json.dumps({'key1': 'value1'}),
+                'invalid':'invalid json blob',
+                'sq_dict': json.dumps({"foo'bar": "value"}),
+                'dq_dict': json.dumps({'foo"bar': "value"})
                 }},
         )
         plugin = pm.load_plugin('configurable_worker')
@@ -159,7 +159,7 @@ class TestPluginManager(unittest.TestCase):
         self.assertEqual(plugin.getjson_option('dict'), {'key1':'value1'})
         self.assertEqual(plugin.getjson_option('sq_dict'), {"foo'bar": "value"})
         self.assertEqual(plugin.getjson_option('dq_dict'), {'foo"bar': "value"})
-        with self.assertRaises(SyntaxError) as exc:
+        with self.assertRaises(json.decoder.JSONDecodeError) as exc:
             plugin.getjson_option('invalid')
 
     def test_plugin_opts_from_stoq_cfg(self):

--- a/stoq/tests/test_plugin_manager.py
+++ b/stoq/tests/test_plugin_manager.py
@@ -133,9 +133,8 @@ class TestPluginManager(unittest.TestCase):
         self.assertEqual(plugin.getjson_option('dict'), {'key':'value'})
         self.assertEqual(plugin.getjson_option('sq_dict'), {"bar'foo": "value"})
         self.assertEqual(plugin.getjson_option('dq_dict'), {'bar"foo': "value"})
-        with self.assertRaises(StoqException) as exc:
+        with self.assertRaises(SyntaxError) as exc:
             plugin.getjson_option('invalid')
-        self.assertTrue('Unable to parse [options] -> invalid as JSON.' in str(exc.exception))
 
         # Test fallback
         self.assertEqual(plugin.getjson_option('doesnotexist'), {})
@@ -160,9 +159,8 @@ class TestPluginManager(unittest.TestCase):
         self.assertEqual(plugin.getjson_option('dict'), {'key1':'value1'})
         self.assertEqual(plugin.getjson_option('sq_dict'), {"foo'bar": "value"})
         self.assertEqual(plugin.getjson_option('dq_dict'), {'foo"bar': "value"})
-        with self.assertRaises(StoqException) as exc:
+        with self.assertRaises(SyntaxError) as exc:
             plugin.getjson_option('invalid')
-        self.assertTrue('Unable to parse [options] -> invalid as JSON.' in str(exc.exception))
 
     def test_plugin_opts_from_stoq_cfg(self):
         s = Stoq(base_dir=utils.get_data_dir())

--- a/stoq/tests/test_plugin_manager.py
+++ b/stoq/tests/test_plugin_manager.py
@@ -128,13 +128,41 @@ class TestPluginManager(unittest.TestCase):
         plugin = pm.load_plugin('configurable_worker')
         self.assertEqual(plugin.get_important_option(), 'cybercybercyber')
 
+        # Test StoqConfigParser.getjson reading from configuration file
+        self.assertEqual(plugin.getjson_option('list'), ['item1', 'item2'])
+        self.assertEqual(plugin.getjson_option('dict'), {'key':'value'})
+        self.assertEqual(plugin.getjson_option('sq_dict'), {"bar'foo": "value"})
+        self.assertEqual(plugin.getjson_option('dq_dict'), {'bar"foo': "value"})
+        with self.assertRaises(StoqException) as exc:
+            plugin.getjson_option('invalid')
+        self.assertTrue('Unable to parse [options] -> invalid as JSON.' in str(exc.exception))
+
+        # Test fallback
+        self.assertEqual(plugin.getjson_option('doesnotexist'), {})
+
     def test_plugin_opts(self):
         pm = StoqPluginManager(
             [utils.get_plugins_dir()],
-            {'configurable_worker': {'crazy_runtime_option': 16}},
+            {'configurable_worker': {
+                'crazy_runtime_option': 16,
+                'list': ['item3', 'item4'],
+                'dict': {'key1': 'value1'},
+                'invalid':'',
+                'sq_dict': {"foo'bar": "value"},
+                'dq_dict': {'foo"bar': "value"}
+                }},
         )
         plugin = pm.load_plugin('configurable_worker')
         self.assertEqual(plugin.get_crazy_runtime_option(), 16)
+
+        # Test StoqConfigParser.getjson reading from plugin_opts
+        self.assertEqual(plugin.getjson_option('list'), ['item3', 'item4'])
+        self.assertEqual(plugin.getjson_option('dict'), {'key1':'value1'})
+        self.assertEqual(plugin.getjson_option('sq_dict'), {"foo'bar": "value"})
+        self.assertEqual(plugin.getjson_option('dq_dict'), {'foo"bar': "value"})
+        with self.assertRaises(StoqException) as exc:
+            plugin.getjson_option('invalid')
+        self.assertTrue('Unable to parse [options] -> invalid as JSON.' in str(exc.exception))
 
     def test_plugin_opts_from_stoq_cfg(self):
         s = Stoq(base_dir=utils.get_data_dir())


### PR DESCRIPTION
getjson worked fine when the options were in the configuration file, but failed when options were specified via plugin_opts. This was since Python does not store dictionaries with double quotes, and json.loads failed to properly process a string. I replaced with ast.lieral_eval and beefed up the tests to make sure it works for both config files and plugin_opts