### PR TITLE
Fixed typo, and added space before code (in core.py) so that it gets …

### DIFF
--- a/docs/dev/upgrading_plugins.rst
+++ b/docs/dev/upgrading_plugins.rst
@@ -10,9 +10,9 @@ With the release of stoQ v3, a few enhancements were introduced that requires v2
 be slightly modified for use with v3. Some key changes include:
 
     - Full asyncio support with all plugins
-    - The entire request state is passed to dispatchers, workers, and archivers. This 
+    - The entire request state is passed to dispatchers, workers, and archivers. This
       includes making all payloads, and their respective results, available to them.
-    - A ``Logger`` object is now available to all plugins upono instantiation
+    - A ``Logger`` object is now available to all plugins upon instantiation
     - Errors from plugins are no longer simply a list of strings, they are now a list
       of ``Error`` objects
     - Configuration parameters are passed to each plugin as a ``StoqConfigParser`` object

--- a/stoq/core.py
+++ b/stoq/core.py
@@ -110,6 +110,7 @@
     retrieved from multiple disparate data sources using `Archiver` plugins.
 
     1. First, import the required class:
+
         >>> import asyncio
         >>> from stoq import Stoq
 


### PR DESCRIPTION
Previous update to the documentation took out empty line that appears to be important, it changed formatting slightly.  Also fixed a typo in the FAQ section.