### PR TITLE
Added worker plugin name in debug logging for completed scan

### DIFF
--- a/stoq/core.py
+++ b/stoq/core.py
@@ -943,7 +943,7 @@ class Stoq(StoqPluginManager):
         ]
 
         self.log.debug(
-            f'Completed scan of {payload.results.payload_id} with '
+            f'Completed scan of {payload.results.payload_id} with WorkerPlugin {plugin.plugin_name} '
             f'{len(worker_response.results) if worker_response.results else 0} result keys, '  # type: ignore
             f'{len(additional_dispatches)} additional dispatches, and '
             f'{len(extracted_payloads)} extracted payloads'


### PR DESCRIPTION
I was curious to see the asyncio in action and the debug logging did not make it clear which WorkerPlugin completed it's scan.  I added this in this PR.

Here is what the log looks like now (red underline for what I added):
![image](https://user-images.githubusercontent.com/11530375/78805657-adb7a780-798f-11ea-9d09-61bdb26aa713.png)

I am not sure the asyncio is behaving as I expected it to.  I always see something like this:
```
Starting scan...A
Completed scan...A
Starting scan...B
Completed scan...B
Starting scan...C
Completed scan...C
Starting scan... D
Completed scan...D
```

I would have expected something more like:
```
Starting scan...A
Starting scan...B
Starting scan...C
Completed scan...B
Starting scan... D
Completed scan...A
Completed scan...C
Completed scan...D
```

