### PR TITLE
Fix dispatch_to documentation in worker.py

### DIFF
--- a/stoq/plugins/worker.py
+++ b/stoq/plugins/worker.py
@@ -174,7 +174,7 @@
 
     ::
 
-        >>> meta = PayloadMeta(dispatch_to='yara')
+        >>> meta = PayloadMeta(dispatch_to=['yara'])
         >>> extracted_payload = ExtractedPayload(b'this is a payload with bad stuff', meta)
 
 


### PR DESCRIPTION
`dispatch_to` is expected to be a list, not a string.  Updated doc string to match tests / other examples.  